### PR TITLE
Read points in get_entity_by_ref_tool; reject non-computable roles upfront (2.3.1)

### DIFF
--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -935,6 +935,33 @@ def create_entity_tool(
     )
 
 
+def _format_userstory_points(entity: Any, project: Any) -> Dict[str, float]:
+    """Resolve a user story's per-role ``points`` dict to the human-readable
+    ``{role_name: point_value}`` shape that ``set_userstory_points_tool``
+    accepts as input. Returns an empty dict if ``entity.points`` is empty
+    or unset.
+
+    Roles whose ID is no longer in ``project.list_roles()`` (deleted/stale)
+    and assignments pointing to the "?" (unestimated, ``value=None``)
+    point are silently dropped — consumers see only role-name keys with
+    concrete numeric values, never partial or null entries.
+    """
+    raw_points = getattr(entity, "points", None) or {}
+    if not raw_points:
+        return {}
+    role_id_to_name = {str(r.id): r.name for r in project.list_roles()}
+    point_id_to_value = {
+        p.id: p.value for p in project.list_points() if p.value is not None
+    }
+    out: Dict[str, float] = {}
+    for role_id, point_id in raw_points.items():
+        role_name = role_id_to_name.get(str(role_id))
+        point_value = point_id_to_value.get(point_id)
+        if role_name and point_value is not None:
+            out[role_name] = point_value
+    return out
+
+
 def _coerce_to_aware_datetime(value: Any) -> Optional[datetime]:
     """Best-effort coerce a Taiga timestamp value to tz-aware UTC datetime.
 
@@ -1461,7 +1488,9 @@ def get_entity_by_ref_tool(project_slug: str, entity_ref: int, entity_type: str)
         watchers = [get_user(w) for w in watchers]
     result["watchers"] = watchers
 
-    # For userstories, include the count of related tasks.
+    # For userstories, include the count of related tasks AND the
+    # per-role story points (symmetric to set_userstory_points_tool's
+    # input shape: {"Developer": 5, "UX": 2}).
     if norm_type == "us":
         result["related"]["tasks"] = [
             {
@@ -1473,6 +1502,7 @@ def get_entity_by_ref_tool(project_slug: str, entity_ref: int, entity_type: str)
             }
             for task in entity.list_tasks()
         ]
+        result["points"] = _format_userstory_points(entity, project)
     if norm_type == "task":
         result["user_story_extra_info"] = entity.user_story_extra_info
     if norm_type == "epic":
@@ -2673,6 +2703,13 @@ def set_userstory_points_tool(
     (unestimated) point has value=None and cannot be set via this tool;
     use the Taiga UI for that.
 
+    The target role MUST be configured as **computable** in the project
+    (Taiga admin → Members/Roles → "Compute story points for this role").
+    Non-computable roles are rejected by Taiga's userstory PATCH endpoint
+    with a generic ``Invalid role id`` error; this tool surfaces that
+    upfront as a 400 with ``non_computable_roles`` so the user knows to
+    flip the project setting.
+
     Existing points for roles NOT included in the ``points`` dict are
     preserved.
 
@@ -2742,12 +2779,21 @@ def set_userstory_points_tool(
         }
         unresolved_roles: List[str] = []
         unresolved_values: List[Dict[str, Any]] = []
+        non_computable_roles: List[str] = []
         resolved: Dict[str, float] = {}
 
         for role_name, value in points.items():
             role = role_by_name.get(role_name.lower())
             if role is None:
                 unresolved_roles.append(role_name)
+                continue
+            # Taiga's userstory PATCH only accepts role IDs whose
+            # ``computable`` flag is True. Non-computable roles fail
+            # server-side with a generic "Invalid role id" message —
+            # we catch them here so the caller knows to flip the
+            # project setting instead of debugging payload shape.
+            if not getattr(role, "computable", True):
+                non_computable_roles.append(role_name)
                 continue
             point_id = point_id_by_value.get(value)
             if point_id is None:
@@ -2756,13 +2802,29 @@ def set_userstory_points_tool(
             new_points[str(role.id)] = point_id
             resolved[role_name] = value
 
-        if unresolved_roles or unresolved_values:
+        if unresolved_roles or unresolved_values or non_computable_roles:
+            error_parts = []
+            if non_computable_roles:
+                error_parts.append(
+                    f"Roles not computable for points "
+                    f"(enable 'Compute story points for this role' in "
+                    f"Taiga project admin -> Members/Roles): "
+                    f"{non_computable_roles}"
+                )
+            if unresolved_roles:
+                error_parts.append(f"Unknown roles: {unresolved_roles}")
+            if unresolved_values:
+                error_parts.append(f"Unknown point values: {unresolved_values}")
             return json.dumps(
                 {
-                    "error": "Could not resolve all roles and/or point values.",
+                    "error": "; ".join(error_parts),
                     "unresolved_roles": unresolved_roles,
                     "unresolved_values": unresolved_values,
+                    "non_computable_roles": non_computable_roles,
                     "available_roles": sorted(r.name for r in roles),
+                    "computable_roles": sorted(
+                        r.name for r in roles if getattr(r, "computable", True)
+                    ),
                     "available_point_values": sorted(point_id_by_value.keys()),
                     "code": 400,
                 },

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -1406,7 +1406,13 @@ def get_entity_by_ref_tool(project_slug: str, entity_ref: int, entity_type: str)
                     "diff": { "description": ["", "Updated description"] },
                 },
                 ...
-            ]
+            ],
+            // For ``entity_type='userstory'`` only — per-role story
+            // points, role-name keys mapping to numeric values,
+            // symmetric to ``set_userstory_points_tool``'s input.
+            // Empty dict when nothing is set; roles assigned to "?"
+            // (unestimated) or stale role-ids are silently dropped.
+            "points": {"Developer": 5, "UX": 2}
         }
     """
     norm_type = normalize_entity_type(entity_type)
@@ -2722,9 +2728,26 @@ def set_userstory_points_tool(
 
     Returns:
         JSON with the resolved points and a URL to the user story. On
-        failure: a 400-coded error listing the roles or values that
-        could not be resolved, plus the available roles and point
-        values for diagnostics.
+        failure: a 400-coded error with the following diagnostic fields
+        (each populated only for the failure modes that occurred, so
+        the LLM can branch its retry strategy by which list is
+        non-empty):
+
+        - ``unresolved_roles``: role-name strings the caller passed
+          that don't exist in the project at all.
+        - ``unresolved_values``: ``[{role, value}]`` pairs whose value
+          isn't part of the project's configured points scale.
+        - ``non_computable_roles``: role names that DO exist but have
+          ``computable=False``; Taiga rejects points assignment for
+          those. Remediate via Taiga project admin → Members/Roles →
+          "Compute story points for this role".
+        - ``available_roles``: every role name the project knows about
+          (sorted alphabetically; deterministic for the LLM to grep).
+        - ``computable_roles``: subset of ``available_roles`` whose
+          ``computable`` flag is True — these are the only role names
+          the call could possibly have succeeded with.
+        - ``available_point_values``: every numeric value in the
+          project's points scale, sorted ascending.
 
     Examples:
         set_userstory_points_tool("wahed", 34, {"Developer": 5})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.3.0"
+version = "2.3.1"
 description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport."
 authors = []
 readme = "README.md"

--- a/tests/unit_tests/test_get_entity_by_ref_tool.py
+++ b/tests/unit_tests/test_get_entity_by_ref_tool.py
@@ -1,7 +1,10 @@
 import pytest
 from langchain_core.tools import BaseTool
 
-from langchain_taiga.tools.taiga_tools import get_entity_by_ref_tool
+from langchain_taiga.tools.taiga_tools import (
+    _format_userstory_points,
+    get_entity_by_ref_tool,
+)
 from langchain_tests.unit_tests import ToolsUnitTests
 
 @pytest.fixture(autouse=True)
@@ -34,3 +37,69 @@ class TestGetEntityUnit(ToolsUnitTests):
         have {"name", "id", "args"} keys.
         """
         return {"project_slug": "slug", "entity_ref": 555, "entity_type": "us"}
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests for ``_format_userstory_points`` — the helper that
+# produces the ``points`` field added to the ``get_entity_by_ref_tool``
+# response for user stories. Lightweight fakes keep the test focused on
+# the {role_id: point_id} -> {role_name: point_value} translation; the
+# tool's other heavy machinery (history, tasks, custom attributes) is
+# tested elsewhere via integration paths.
+# ---------------------------------------------------------------------------
+
+
+class _Stub:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+def _project(roles, points):
+    return _Stub(list_roles=lambda: roles, list_points=lambda: points)
+
+
+def test_format_userstory_points_returns_role_name_to_value(monkeypatch):
+    entity = _Stub(points={"19": 103, "20": 101})
+    project = _project(
+        roles=[_Stub(id=19, name="Developer"), _Stub(id=20, name="UX")],
+        points=[
+            _Stub(id=100, value=1),
+            _Stub(id=101, value=2),
+            _Stub(id=103, value=5),
+        ],
+    )
+    assert _format_userstory_points(entity, project) == {
+        "Developer": 5,
+        "UX": 2,
+    }
+
+
+def test_format_userstory_points_empty_when_unset():
+    entity = _Stub(points=None)
+    project = _project(
+        roles=[_Stub(id=19, name="Developer")],
+        points=[_Stub(id=100, value=1)],
+    )
+    assert _format_userstory_points(entity, project) == {}
+
+
+def test_format_userstory_points_drops_stale_role_id_and_unestimated():
+    """A role-id key that's no longer present on the project (deleted
+    role) and a point assignment to the "?" point (value=None) must
+    both be silently dropped — consumers see only role-name keys with
+    concrete numeric values."""
+    entity = _Stub(points={"19": 103, "999": 100, "20": 351})
+    project = _project(
+        roles=[_Stub(id=19, name="Developer"), _Stub(id=20, name="UX")],
+        points=[
+            _Stub(id=100, value=1),
+            _Stub(id=103, value=5),
+            _Stub(id=351, value=None),  # the "?" unestimated point
+        ],
+    )
+    out = _format_userstory_points(entity, project)
+    # Only Developer survives:
+    #   - role 999 not in project.list_roles() -> dropped
+    #   - UX (role 20) points to "?" (value None)        -> dropped
+    assert out == {"Developer": 5}

--- a/tests/unit_tests/test_set_userstory_points_tool.py
+++ b/tests/unit_tests/test_set_userstory_points_tool.py
@@ -55,9 +55,12 @@ class TestSetUserstoryPointsUnit(ToolsUnitTests):
 
 
 class _FakeRole:
-    def __init__(self, rid, name):
+    def __init__(self, rid, name, computable=True):
         self.id = rid
         self.name = name
+        # Default ``computable=True`` keeps every pre-existing test
+        # green — only the dedicated non-computable test flips it off.
+        self.computable = computable
 
 
 class _FakePoint:
@@ -254,6 +257,44 @@ def test_us_not_found_returns_404(monkeypatch):
         "points": {"Developer": 1},
     })
     assert json.loads(raw)["code"] == 404
+
+
+def test_non_computable_role_returns_400_with_diagnostic(monkeypatch):
+    """Production found this the hard way on project ``wahed``: every
+    role had ``computable=False``, so Taiga's userstory PATCH rejected
+    the request with a generic ``Invalid role id`` server-side error
+    that came back as a 500 from the surrounding except. Surface it
+    upfront with a clear remediation message + ``non_computable_roles``
+    list so the caller knows to flip the project setting instead of
+    debugging payload shape."""
+    us = _FakeUS(ref=34, version=2, points={})
+    project = _FakeProject(
+        us=us,
+        roles=[
+            _FakeRole(199, "Product Owner", computable=False),
+            _FakeRole(221, "Developer", computable=False),
+        ],
+        point_scale=[_FakePoint(357, 5)],
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+
+    raw = set_userstory_points_tool.invoke({
+        "project_slug": "wahed",
+        "user_story_ref": 34,
+        "points": {"Developer": 5},
+    })
+    payload = json.loads(raw)
+    assert payload["code"] == 400
+    assert "Developer" in payload["non_computable_roles"]
+    # Empty when no role in the project is computable — the diagnostic
+    # tells the LLM there's no valid role to fall back to either.
+    assert payload["computable_roles"] == []
+    # The remediation hint is in the error message — must mention the
+    # exact Taiga UI path so the LLM can repeat it back to the user.
+    assert "Compute story points for this role" in payload["error"]
+    # Must NOT have written anything (atomicity).
+    assert us.patch_calls == []
+    assert us.points == {}
 
 
 def test_calls_patch_not_update(fake_env):


### PR DESCRIPTION
## Summary

Two related changes uncovered by a prod-bug investigation against the `wahed` project, where every `set_userstory_points_tool` call was returning HTTP 500 with the cryptic `Invalid role id '221'` server-side error from Taiga.

## Root cause of the prod bug (the real one)

Probed live `wahed`:

```
roles:
  199 Product Owner   computable=False
  200 Stakeholder     computable=False
  221 Developer       computable=False
```

All three roles in `wahed` have `computable=False`. Taiga's userstory PATCH validator rejects any role-ID whose `role.computable` is False, but it returns the misleading `Invalid role id '<id>'` — not "role not configured for points estimation". The role IS valid; it's just not enabled for story-point estimation. Project admins fix this in Taiga UI → Members → Roles → "Compute story points for this role".

Code-side fix: catch this client-side instead of letting the user chase payload-shape ghosts.

## What changed

### `set_userstory_points_tool` — computable-validation gate

```python
if not getattr(role, "computable", True):
    non_computable_roles.append(role_name)
    continue
```

400 response on rejection now carries:
- `non_computable_roles: ["Developer"]` — the rejected names
- `computable_roles: []` — what the project actually allows (empty here, signalling no fallback exists)
- The standard `available_roles` and `available_point_values` for unrelated diagnostics
- A remediation message pointing at `Taiga project admin → Members/Roles → "Compute story points for this role"`

Docstring updated to mention the `computable` requirement upfront so the LLM steers users correctly without hitting the 400.

### `get_entity_by_ref_tool` — read the per-role points

User-story responses now include a `points` field:

```json
"points": {"Developer": 5, "UX": 2}
```

Shape is symmetric to `set_userstory_points_tool`'s input — a read + write round-trip stays in the same vocabulary. Logic lives in a new helper `_format_userstory_points(entity, project)` so the ID-to-name resolution is testable without spinning up the full get-by-ref machinery (status lookups, custom-attribute fetches, history pagination).

Edge cases the helper silently drops:
- Stale role-ids (role-id key in `us.points` no longer in `project.list_roles()`)
- Assignments pointing to the `?` (unestimated, `value=None`) point

Consumers see only role-name keys with concrete numeric values — never partial or null entries.

## Why both in one PR

They're complementary: the new read path lets the same caller diagnose what's currently set on a story before deciding what to write, and the computable-validation surfaces the failure mode the user just hit. Bundling avoids two close-spaced 2.3.x releases.

## Validation

- `make test` (or conda equivalent): **171 passed, 1 skipped** (was 167 before this PR).
- New tests:
  - `test_non_computable_role_returns_400_with_diagnostic` — locks the new client-side rejection path.
  - `test_format_userstory_points_returns_role_name_to_value` — happy path.
  - `test_format_userstory_points_empty_when_unset` — `entity.points = None` → `{}`.
  - `test_format_userstory_points_drops_stale_role_id_and_unestimated` — both edge cases in one test.
- Existing tests untouched (the new computable check defaults to `True` via `getattr`, so pre-existing fakes without the attr still pass).

## Notable

- **Version bump 2.3.0 → 2.3.1**: patch, because the changes are additive (new response field, new error path) and don't break any existing caller.
- **Release flow**: `ci_publish.yml` auto-publishes to PyPI on merge. After merge, the `taiga` repo's `Jenkinsfile` doesn't strictly need a re-bump (`TAIGA_MCP_VERSION` is already at `2.3.0`, which satisfies most callers); but if you want the deployed `taiga-mcp` to ship 2.3.1, bump default → `2.3.1` in `Shikenso-Analytics/taiga` and trigger one explicit Jenkins build to seed the param-cache.
- **User action still required for `wahed`**: enable `computable=True` on the Developer role via the Taiga UI before retrying `set_userstory_points_tool` — this PR makes the failure mode loud, not the project setting.

## Test plan

- [x] Targeted: `pytest tests/unit_tests/test_set_userstory_points_tool.py tests/unit_tests/test_get_entity_by_ref_tool.py -v` (25/25 pass).
- [x] Full suite: `env -u TAIGA_URL pytest tests/unit_tests/` (171 pass).
- [ ] Live smoke after enabling computable on Developer in `wahed` UI: round-trip `get_entity_by_ref_tool` → `set_userstory_points_tool({"Developer": 5})` → `get_entity_by_ref_tool` and verify the field is updated.
