### PR TITLE
Fix sort_kanban N+1, use us.total_points, add outer try (2.3.2)

### DIFF
--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2414,14 +2414,48 @@ def sort_kanban_by_rice_tool(
         # ThreadPoolExecutor gives us bounded concurrency over python-taiga's
         # sync calls (each thread reuses the requests.Session which is
         # threadsafe for read-side GETs).
+        #
+        # Per-story fetch failures are RECORDED, not swallowed — a fetch
+        # failure means we can't read that story's reach/impact/confidence
+        # custom attributes, which defaults RICE to 1×1×1=1. That shoves
+        # the story to the bottom of its column, which would silently
+        # mis-sort a real high-priority item if the failure is transient.
+        # We surface the failed refs in ``attribute_fetch_errors`` so the
+        # caller can decide whether to retry (and so partial failures
+        # aren't invisible).
+        attr_fetch_errors = []
+
         def _fetch_us_attrs(us):
             try:
-                return us.ref, us.get_attributes().get("attributes_values", {}) or {}
-            except Exception:
-                return us.ref, {}
+                attrs = us.get_attributes().get("attributes_values", {}) or {}
+                return us.ref, attrs, None
+            except Exception as exc:
+                return us.ref, {}, f"{type(exc).__name__}: {exc}"
 
+        us_attr_values = {}
         with ThreadPoolExecutor(max_workers=10) as executor:
-            us_attr_values = dict(executor.map(_fetch_us_attrs, stories))
+            for ref, attrs, err in executor.map(_fetch_us_attrs, stories):
+                us_attr_values[ref] = attrs
+                if err is not None:
+                    attr_fetch_errors.append({"ref": ref, "error": err})
+
+        # Total-failure guard: if every per-story fetch failed, the RICE
+        # numbers we'd compute are uniformly garbage and reordering the
+        # board would be actively harmful. Bail loudly.
+        if stories and len(attr_fetch_errors) == len(stories):
+            return json.dumps(
+                {
+                    "error": (
+                        "All per-story custom-attribute fetches failed; "
+                        "cannot compute RICE scores reliably. Likely a "
+                        "Taiga API outage or auth problem — refusing to "
+                        "reorder the Kanban from defaults."
+                    ),
+                    "code": 500,
+                    "attribute_fetch_errors": attr_fetch_errors[:10],
+                },
+                indent=2,
+            )
 
         # --- 4. Pre-group stories by epic from inline ``us.epics`` data.
         # Pre-2.3.2 the per-epic ``epic.list_user_stories()`` was an
@@ -2686,6 +2720,15 @@ def sort_kanban_by_rice_tool(
                 "epic_multiplicators_used": len(epic_multiplicators) > 0,
                 "epic_completions": {str(k): round(v * 100) for k, v in epic_completions.items()},
                 "warnings": warnings if warnings else None,
+                # ``None`` when every per-story fetch succeeded; otherwise
+                # a list of ``{"ref": <us-ref>, "error": "<msg>"}`` for
+                # the stories whose RICE custom attributes couldn't be
+                # read. Those stories sorted with reach/impact/confidence
+                # defaulted to 1, so their placement is unreliable; the
+                # caller may want to retry the tool or reorder by hand.
+                "attribute_fetch_errors": (
+                    attr_fetch_errors if attr_fetch_errors else None
+                ),
                 "columns_updated": results,
             },
             indent=2,

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2351,7 +2351,9 @@ def sort_kanban_by_rice_tool(
         sort_kanban_by_rice_tool("wahed", descending=False)
     """
     import requests
+    import traceback
     from collections import defaultdict
+    from concurrent.futures import ThreadPoolExecutor
 
     project = get_project(project_slug)
     if not project:
@@ -2360,11 +2362,15 @@ def sort_kanban_by_rice_tool(
             indent=2,
         )
 
-    # Get RICE custom attribute IDs for user stories (effort comes from the
-    # sum of all roles' story points — see the effort block below)
-    rice_attrs = {}
-    blocked_by_attr_id = None
+    # Catch-all so any unexpected failure produces a JSON payload instead
+    # of bubbling up as the harness-generic "Error occurred during tool
+    # execution" — without this the caller saw nothing useful when the
+    # FastMCP worker died or got killed by k8s liveness probe (the prod
+    # symptom that prompted this refactor).
     try:
+        # --- 1. Discover relevant custom-attribute IDs (cheap, ~1 call each)
+        rice_attrs = {}
+        blocked_by_attr_id = None
         for attr in project.list_user_story_attributes():
             name_lower = attr.name.lower()
             if name_lower == "reach":
@@ -2375,90 +2381,117 @@ def sort_kanban_by_rice_tool(
                 rice_attrs["confidence"] = str(attr.id)
             elif name_lower == "blocked by":
                 blocked_by_attr_id = str(attr.id)
-    except Exception as e:
-        return json.dumps(
-            {"error": f"Error listing custom attributes: {str(e)}", "code": 500},
-            indent=2,
-        )
 
-    if len(rice_attrs) < 3:
-        return json.dumps(
-            {
-                "error": "RICE custom attributes not fully configured",
-                "found": list(rice_attrs.keys()),
-                "required": ["reach", "impact", "confidence"],
-                "code": 400,
-            },
-            indent=2,
-        )
+        if len(rice_attrs) < 3:
+            return json.dumps(
+                {
+                    "error": "RICE custom attributes not fully configured",
+                    "found": list(rice_attrs.keys()),
+                    "required": ["reach", "impact", "confidence"],
+                    "code": 400,
+                },
+                indent=2,
+            )
 
-    # Build point ID -> value lookup for summing per-role story points.
-    # Effort = sum of every role's points (Developer + UX + Design + …),
-    # so the tool adapts to per-project role configuration without the
-    # old hard-coded "role-id 19 == Developer" magic value.
-    point_id_to_value = {p.id: p.value for p in project.list_points() if p.value is not None}
+        multiplicator_attr_id = None
+        try:
+            for attr in project.list_epic_attributes():
+                if attr.name.lower() == "multiplicator":
+                    multiplicator_attr_id = str(attr.id)
+                    break
+        except Exception:
+            pass  # Multiplicator is optional
 
-    # Get Epic Multiplicator custom attribute ID
-    multiplicator_attr_id = None
-    try:
-        for attr in project.list_epic_attributes():
-            if attr.name.lower() == "multiplicator":
-                multiplicator_attr_id = str(attr.id)
-                break
-    except Exception:
-        pass  # Multiplicator is optional
+        # --- 2. Fetch all stories ONCE. The list endpoint already inlines
+        # ``points``, ``total_points``, ``epics``, ``status``, ``swimlane``,
+        # ``due_date``, ``is_closed`` — so we don't need any per-US calls
+        # for those, only for the custom-attribute values (RICE).
+        stories = list(project.list_user_stories())
 
-    # Build epic multiplicator + completion cache
-    epic_multiplicators = {}   # epic_id -> multiplicator value
-    epic_completions = {}      # epic_id -> completion fraction (0.0–1.0)
-    try:
-        for epic in project.list_epics():
-            # Multiplicator custom attribute
-            if multiplicator_attr_id:
-                attrs = epic.get_attributes()
-                attr_values = attrs.get("attributes_values", {})
-                mult = attr_values.get(multiplicator_attr_id, 1.0) or 1.0
-                epic_multiplicators[epic.id] = float(mult)
-
-            # Epic completion percentage based on closed user stories
+        # --- 3. Parallel-fetch custom attributes for all stories. Pre-2.3.2
+        # this was a serial N+1 that pushed wall time past the FastMCP
+        # worker's k8s liveness probe on projects with ~40+ stories.
+        # ThreadPoolExecutor gives us bounded concurrency over python-taiga's
+        # sync calls (each thread reuses the requests.Session which is
+        # threadsafe for read-side GETs).
+        def _fetch_us_attrs(us):
             try:
-                related_us = epic.list_user_stories()
-                total = len(related_us)
-                if total > 0:
-                    closed = sum(1 for us in related_us if getattr(us, "is_closed", False))
-                    epic_completions[epic.id] = closed / total
-                else:
-                    epic_completions[epic.id] = 0.0
+                return us.ref, us.get_attributes().get("attributes_values", {}) or {}
             except Exception:
-                epic_completions[epic.id] = 0.0
-    except Exception:
-        pass  # If we can't get epics, continue without multiplicators
+                return us.ref, {}
 
-    # Get all user stories with their RICE scores
-    stories_with_rice = []
-    try:
-        for us in project.list_user_stories():
-            attrs = us.get_attributes()
-            attr_values = attrs.get("attributes_values", {})
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            us_attr_values = dict(executor.map(_fetch_us_attrs, stories))
+
+        # --- 4. Pre-group stories by epic from inline ``us.epics`` data.
+        # Pre-2.3.2 the per-epic ``epic.list_user_stories()`` was an
+        # additional N+1 over epics; this groups in-memory from the
+        # already-fetched stories list, no extra HTTP.
+        epic_to_stories: defaultdict = defaultdict(list)
+        for us in stories:
+            for e in (getattr(us, "epics", None) or []):
+                epic_id = (
+                    e.get("id") if isinstance(e, dict) else getattr(e, "id", None)
+                )
+                if epic_id:
+                    epic_to_stories[epic_id].append(us)
+
+        epic_completions = {
+            epic_id: (
+                sum(1 for us in uss if getattr(us, "is_closed", False)) / len(uss)
+                if uss
+                else 0.0
+            )
+            for epic_id, uss in epic_to_stories.items()
+        }
+
+        # --- 5. Epic multiplicator (only if the project has the custom attr)
+        # is the one remaining per-epic fetch. Parallelize it too. The list
+        # of epics is bounded and usually small (<10) so even the serial
+        # version is fast — but parallel keeps it consistent.
+        epic_multiplicators = {}
+        if multiplicator_attr_id:
+            try:
+                epics_list = list(project.list_epics())
+
+                def _fetch_epic_mult(epic):
+                    try:
+                        attrs = epic.get_attributes()
+                        attr_values = attrs.get("attributes_values", {}) or {}
+                        mult = attr_values.get(multiplicator_attr_id, 1.0) or 1.0
+                        return epic.id, float(mult)
+                    except Exception:
+                        return epic.id, 1.0
+
+                with ThreadPoolExecutor(max_workers=10) as executor:
+                    epic_multiplicators = dict(
+                        executor.map(_fetch_epic_mult, epics_list)
+                    )
+            except Exception:
+                pass  # Multiplicator is optional; missing epics is non-fatal.
+
+        # --- 6. Build the per-story RICE rows from already-fetched data.
+        # ``us.total_points`` is what Taiga itself shows in the UI as the
+        # story's effort (sum across computable roles). We use it directly
+        # instead of re-summing ``us.points.values()`` against a separate
+        # ``project.list_points()`` lookup — eliminates one HTTP call AND
+        # one source of bug surface (the role-id-19 hardcoded lookup that
+        # 2.3.0 removed had its own zero-effort regression).
+        stories_with_rice = []
+        for us in stories:
+            attr_values = us_attr_values.get(us.ref, {})
 
             reach = attr_values.get(rice_attrs["reach"], 1) or 1
             impact = attr_values.get(rice_attrs["impact"], 1) or 1
             confidence = attr_values.get(rice_attrs["confidence"], 1) or 1
 
-            # Effort = sum of every role's points. ``or 0`` covers the
-            # "?" (unestimated) point whose value is None and which is
-            # therefore filtered out of ``point_id_to_value`` above.
-            effort = sum(
-                point_id_to_value.get(point_id, 0) or 0
-                for point_id in (us.points or {}).values()
-            )
+            effort = getattr(us, "total_points", None) or 0
 
             if effort and effort > 0:
                 rice_score = (reach * impact * confidence) / effort
             else:
                 rice_score = 0
 
-            # Get Epic Multiplicator and Completion Bonus if user story is linked to an epic
             epic_mult = 1.0
             completion_pct = 0.0
             completion_bonus = 1.0
@@ -2483,14 +2516,10 @@ def sort_kanban_by_rice_tool(
                     completion_pct = epic_completions[epic_id]
                     completion_bonus = calculate_completion_bonus(completion_pct)
 
-            # Get due date for urgency calculation
             due_date = getattr(us, "due_date", None)
-
-            # Calculate urgency based on due date and effort
             urgency = calculate_urgency(due_date, int(effort) if effort else 2)
             final_priority = rice_score * epic_mult * completion_bonus * urgency
 
-            # Get Blocked By reference (extract ref from URL if present)
             blocked_by_ref = None
             if blocked_by_attr_id:
                 blocked_by_url = attr_values.get(blocked_by_attr_id, None)
@@ -2519,167 +2548,164 @@ def sort_kanban_by_rice_tool(
                     "blocked_by_ref": blocked_by_ref,
                 }
             )
-    except Exception as e:
+
+        # --- 7. Group by (status_id, swimlane_id) and sort each group.
+        grouped = defaultdict(list)
+        for s in stories_with_rice:
+            key = (s["status_id"], s["swimlane_id"])
+            grouped[key].append(s)
+
+        for key in grouped:
+            stories = grouped[key]
+            stories.sort(key=lambda x: x["final_priority"], reverse=descending)
+
+            # Reorder: place blocked stories immediately after their blocker
+            # ONLY if the blocked story would otherwise appear ABOVE the blocker.
+            ref_to_story = {s["ref"]: s for s in stories}
+            blocked_stories = [s for s in stories if s["blocked_by_ref"] is not None]
+            for blocked in blocked_stories:
+                blocker_ref = blocked["blocked_by_ref"]
+                if blocker_ref in ref_to_story:
+                    blocker = ref_to_story[blocker_ref]
+                    blocked_idx = stories.index(blocked)
+                    blocker_idx = stories.index(blocker)
+                    if blocked_idx < blocker_idx:
+                        stories.remove(blocked)
+                        # Re-find blocker's index after removal.
+                        blocker_idx = stories.index(blocker)
+                        stories.insert(blocker_idx + 1, blocked)
+            grouped[key] = stories
+
+        # --- 8. Warn on dependency-vs-deadline conflicts.
+        warnings = []
+        for stories in grouped.values():
+            ref_to_story = {s["ref"]: s for s in stories}
+            for story in stories:
+                if story["blocked_by_ref"] and story["due_date"]:
+                    blocker_ref = story["blocked_by_ref"]
+                    if blocker_ref in ref_to_story:
+                        blocker = ref_to_story[blocker_ref]
+                        if not blocker["due_date"]:
+                            warnings.append(
+                                f"⚠️ US #{story['ref']} has due_date ({story['due_date']}) but is blocked by "
+                                f"US #{blocker_ref} which has NO due_date. Consider adding a due_date to #{blocker_ref}."
+                            )
+
+        # --- 9. Push the new order to Taiga, one bulk-call per group.
+        base_url = TAIGA_URL.rstrip("/")
+        api = get_taiga_api(token=_current_taiga_jwt())
+        headers = {
+            "Authorization": f"Bearer {api.token}",
+            "Content-Type": "application/json",
+        }
+
+        results = []
+        for (status_id, swimlane_id), stories in grouped.items():
+            if not stories:
+                continue
+            bulk_ids = [s["id"] for s in stories]
+            data = {
+                "project_id": project.id,
+                "status_id": status_id,
+                "bulk_userstories": bulk_ids,
+            }
+            if swimlane_id:
+                data["swimlane_id"] = swimlane_id
+            try:
+                resp = requests.post(
+                    f"{base_url}/api/v1/userstories/bulk_update_kanban_order",
+                    json=data,
+                    headers=headers,
+                )
+                results.append(
+                    {
+                        "status_id": status_id,
+                        "swimlane_id": swimlane_id,
+                        "success": resp.status_code == 200,
+                        "order": [
+                            {
+                                "ref": s["ref"],
+                                "rice": round(s["rice"], 2),
+                                "effort": s["effort"],
+                                "epic_ref": s["epic_ref"],
+                                "epic_mult": s["epic_mult"],
+                                "completion_pct": round(s["completion_pct"] * 100),
+                                "completion_bonus": round(s["completion_bonus"], 2),
+                                "due_date": s["due_date"],
+                                "urgency": s["urgency"],
+                                "final": round(s["final_priority"], 2),
+                                "blocked_by": s["blocked_by_ref"],
+                            }
+                            for s in stories
+                        ],
+                    }
+                )
+            except Exception as e:
+                results.append(
+                    {
+                        "status_id": status_id,
+                        "swimlane_id": swimlane_id,
+                        "success": False,
+                        "error": str(e),
+                    }
+                )
+
         return json.dumps(
-            {"error": f"Error fetching user stories: {str(e)}", "code": 500},
+            {
+                "sorted": True,
+                "project": project.name,
+                "direction": (
+                    "descending (highest first)"
+                    if descending
+                    else "ascending (lowest first)"
+                ),
+                "formula": "Final Priority = RICE × Epic Multiplicator × Completion Bonus × Urgency Multiplier",
+                "completion_bonus_formula": "1.0 + 0.5 × (closed_stories / total_stories)²",
+                "urgency_formula": "Buffer = Days remaining - Work evenings needed",
+                "story_points_to_evenings": {"2": 1, "4": 2, "5": 3, "6": 4, "7": 6, "8": 10, "9": 15, "10": 20},
+                "completion_bonus_scale": {
+                    "0%": 1.0,
+                    "20%": 1.02,
+                    "50%": 1.13,
+                    "75%": 1.28,
+                    "80%": 1.32,
+                    "90%": 1.41,
+                    "100%": 1.5,
+                },
+                "urgency_multipliers": {
+                    "buffer_negative": 50.0,
+                    "buffer_0_1": 25.0,
+                    "buffer_2_3": 10.0,
+                    "buffer_4_7": 5.0,
+                    "buffer_8_14": 2.0,
+                    "buffer_over_14": 1.5,
+                    "no_deadline": 1.0,
+                },
+                "total_stories": len(stories_with_rice),
+                "deadline_stories": len([s for s in stories_with_rice if s["due_date"]]),
+                "epic_multiplicators_used": len(epic_multiplicators) > 0,
+                "epic_completions": {str(k): round(v * 100) for k, v in epic_completions.items()},
+                "warnings": warnings if warnings else None,
+                "columns_updated": results,
+            },
             indent=2,
         )
 
-    # Group by status_id and swimlane
-    grouped = defaultdict(list)
-    for s in stories_with_rice:
-        key = (s["status_id"], s["swimlane_id"])
-        grouped[key].append(s)
-
-    # Sort each group by Final Priority (RICE × Epic Multiplicator)
-    # Then reorder to place blocked stories immediately after their blocker
-    for key in grouped:
-        stories = grouped[key]
-        # First, sort by final_priority
-        stories.sort(key=lambda x: x["final_priority"], reverse=descending)
-
-        # Build a ref->story mapping for quick lookup
-        ref_to_story = {s["ref"]: s for s in stories}
-
-        # Find blocked stories and their blockers
-        blocked_stories = [s for s in stories if s["blocked_by_ref"] is not None]
-
-        # Reorder: place blocked stories immediately after their blocker
-        # ONLY if the blocked story would appear ABOVE the blocker
-        for blocked in blocked_stories:
-            blocker_ref = blocked["blocked_by_ref"]
-            if blocker_ref in ref_to_story:
-                blocker = ref_to_story[blocker_ref]
-                blocked_idx = stories.index(blocked)
-                blocker_idx = stories.index(blocker)
-
-                # Only move if blocked story is currently ABOVE the blocker
-                if blocked_idx < blocker_idx:
-                    # Remove blocked story from current position
-                    stories.remove(blocked)
-                    # Find blocker's NEW position (shifted after removal) and insert after it
-                    blocker_idx = stories.index(blocker)
-                    stories.insert(blocker_idx + 1, blocked)
-
-        grouped[key] = stories
-
-    # Collect warnings for dependency conflicts (blocked story has due_date but blocker doesn't)
-    warnings = []
-    for stories in grouped.values():
-        ref_to_story = {s["ref"]: s for s in stories}
-        for story in stories:
-            if story["blocked_by_ref"] and story["due_date"]:
-                blocker_ref = story["blocked_by_ref"]
-                if blocker_ref in ref_to_story:
-                    blocker = ref_to_story[blocker_ref]
-                    if not blocker["due_date"]:
-                        warnings.append(
-                            f"⚠️ US #{story['ref']} has due_date ({story['due_date']}) but is blocked by "
-                            f"US #{blocker_ref} which has NO due_date. Consider adding a due_date to #{blocker_ref}."
-                        )
-
-    # Call the bulk_update_kanban_order API for each group
-    base_url = TAIGA_URL.rstrip("/")
-    api = get_taiga_api(token=_current_taiga_jwt())
-    headers = {
-        "Authorization": f"Bearer {api.token}",
-        "Content-Type": "application/json",
-    }
-
-    results = []
-    for (status_id, swimlane_id), stories in grouped.items():
-        if not stories:
-            continue
-
-        bulk_ids = [s["id"] for s in stories]
-
-        data = {
-            "project_id": project.id,
-            "status_id": status_id,
-            "bulk_userstories": bulk_ids,
-        }
-        if swimlane_id:
-            data["swimlane_id"] = swimlane_id
-
-        try:
-            resp = requests.post(
-                f"{base_url}/api/v1/userstories/bulk_update_kanban_order",
-                json=data,
-                headers=headers,
-            )
-            results.append(
-                {
-                    "status_id": status_id,
-                    "swimlane_id": swimlane_id,
-                    "success": resp.status_code == 200,
-                    "order": [
-                        {
-                            "ref": s["ref"],
-                            "rice": round(s["rice"], 2),
-                            "effort": s["effort"],
-                            "epic_ref": s["epic_ref"],
-                            "epic_mult": s["epic_mult"],
-                            "completion_pct": round(s["completion_pct"] * 100),
-                            "completion_bonus": round(s["completion_bonus"], 2),
-                            "due_date": s["due_date"],
-                            "urgency": s["urgency"],
-                            "final": round(s["final_priority"], 2),
-                            "blocked_by": s["blocked_by_ref"],
-                        }
-                        for s in stories
-                    ],
-                }
-            )
-        except Exception as e:
-            results.append(
-                {
-                    "status_id": status_id,
-                    "swimlane_id": swimlane_id,
-                    "success": False,
-                    "error": str(e),
-                }
-            )
-
-    return json.dumps(
-        {
-            "sorted": True,
-            "project": project.name,
-            "direction": (
-                "descending (highest first)"
-                if descending
-                else "ascending (lowest first)"
-            ),
-            "formula": "Final Priority = RICE × Epic Multiplicator × Completion Bonus × Urgency Multiplier",
-            "completion_bonus_formula": "1.0 + 0.5 × (closed_stories / total_stories)²",
-            "urgency_formula": "Buffer = Days remaining - Work evenings needed",
-            "story_points_to_evenings": {"2": 1, "4": 2, "5": 3, "6": 4, "7": 6, "8": 10, "9": 15, "10": 20},
-            "completion_bonus_scale": {
-                "0%": 1.0,
-                "20%": 1.02,
-                "50%": 1.13,
-                "75%": 1.28,
-                "80%": 1.32,
-                "90%": 1.41,
-                "100%": 1.5,
+    except Exception as e:
+        # Outer safety net so any uncaught failure produces a JSON
+        # payload — without this the FastMCP harness reports the generic
+        # "Error occurred during tool execution" with no diagnostic.
+        return json.dumps(
+            {
+                "error": (
+                    f"Unexpected error in sort_kanban_by_rice_tool: "
+                    f"{type(e).__name__}: {str(e)}"
+                ),
+                "code": 500,
+                "trace_tail": traceback.format_exc().splitlines()[-5:],
             },
-            "urgency_multipliers": {
-                "buffer_negative": 50.0,
-                "buffer_0_1": 25.0,
-                "buffer_2_3": 10.0,
-                "buffer_4_7": 5.0,
-                "buffer_8_14": 2.0,
-                "buffer_over_14": 1.5,
-                "no_deadline": 1.0,
-            },
-            "total_stories": len(stories_with_rice),
-            "deadline_stories": len([s for s in stories_with_rice if s["due_date"]]),
-            "epic_multiplicators_used": len(epic_multiplicators) > 0,
-            "epic_completions": {str(k): round(v * 100) for k, v in epic_completions.items()},
-            "warnings": warnings if warnings else None,
-            "columns_updated": results,
-        },
-        indent=2,
-    )
+            indent=2,
+        )
 
 
 # NOTE: keep literal dict examples (e.g. ``{"Developer": 5}``) in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.3.1"
+version = "2.3.2"
 description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport."
 authors = []
 readme = "README.md"

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -41,11 +41,17 @@ class _FakePoint:
 
 
 class _FakeUS:
-    def __init__(self, ref, points, attr_values, status=100):
+    def __init__(self, ref, points, attr_values, status=100, total_points=None):
         self.ref = ref
         self.id = ref * 1000
         self.subject = f"US {ref}"
         self.points = points
+        # Taiga's `/userstories?project=X` list endpoint inlines
+        # ``total_points`` (sum across computable roles' assignments) so
+        # since 2.3.2 the tool reads it directly instead of re-summing
+        # ``points.values()`` against a separate ``list_points()`` lookup.
+        # Fakes mirror that contract: the test sets the canonical sum.
+        self.total_points = total_points
         self._attr_values = attr_values
         self.status = status
         self.epics = None
@@ -119,12 +125,16 @@ def _baseline_points():
     ]
 
 
-def test_effort_is_sum_of_all_role_points(monkeypatch, patched_http):
-    """A story with Developer=5 (point id 103) AND UX=2 (point id 101)
-    must produce effort=7 in the response, not effort=5."""
+def test_effort_takes_us_total_points(monkeypatch, patched_http):
+    """Effort = ``us.total_points`` (Taiga-computed sum across all
+    computable roles' point assignments). Pre-2.3.2 we computed this
+    locally from ``us.points`` against a separate ``list_points()``
+    lookup; since 2.3.2 we trust Taiga's own pre-computed field, which
+    is inlined on every list-userstories response."""
     story = _FakeUS(
         ref=34,
-        points={"19": 103, "20": 101},  # Developer=5, UX=2
+        points={"19": 103, "20": 101},  # Developer=5, UX=2 (legacy field)
+        total_points=7.0,                # what Taiga computed
         attr_values={"1": 4, "2": 3, "3": 1},  # reach, impact, confidence
     )
     project = _FakeProject(
@@ -141,18 +151,20 @@ def test_effort_is_sum_of_all_role_points(monkeypatch, patched_http):
     assert len(cols) == 1
     order = cols[0]["order"]
     assert len(order) == 1
-    assert order[0]["effort"] == 7  # 5 (Developer) + 2 (UX)
+    assert order[0]["effort"] == 7.0
 
 
-def test_works_when_developer_role_is_not_id_19(monkeypatch, patched_http):
-    """The pre-2.3.0 hard-coded ``developer_role_id = "19"`` lookup
-    silently produced effort=0 on any project where Developer was a
-    different role-id. This test proves the bug is gone: project where
-    Developer's role-id is 42; story has only Developer=5; effort
-    correctly reads as 5."""
+def test_works_regardless_of_role_id(monkeypatch, patched_http):
+    """Pre-2.3.0 the tool hard-coded ``developer_role_id = "19"`` and
+    silently zeroed effort on projects where Developer was a different
+    role-id. Pre-2.3.2 it summed ``us.points.values()`` itself which
+    needed a separate role/points lookup. Now it reads ``total_points``
+    directly — completely role-id-agnostic, no project-wide lookup,
+    works on any project regardless of how Taiga numbers its roles."""
     story = _FakeUS(
         ref=10,
-        points={"42": 103},  # Developer (id=42) = 5
+        points={"42": 103},  # Developer at role-id 42 (legacy field)
+        total_points=5.0,
         attr_values={"1": 1, "2": 1, "3": 1},
     )
     project = _FakeProject(
@@ -166,4 +178,61 @@ def test_works_when_developer_role_is_not_id_19(monkeypatch, patched_http):
     raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
     payload = json.loads(raw)
     order = payload["columns_updated"][0]["order"]
-    assert order[0]["effort"] == 5
+    assert order[0]["effort"] == 5.0
+
+
+def test_effort_zero_when_no_points_assigned(monkeypatch, patched_http):
+    """Stories without any role-points assigned (``total_points=None``
+    from Taiga) get effort=0 and consequently rice_score=0 — they sort
+    to the bottom of their column instead of crashing the tool. Edge
+    case for newly-created stories that haven't been estimated yet."""
+    story = _FakeUS(
+        ref=99,
+        points={},
+        total_points=None,
+        attr_values={"1": 4, "2": 3, "3": 1},
+    )
+    project = _FakeProject(
+        stories=[story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+    order = payload["columns_updated"][0]["order"]
+    assert order[0]["effort"] == 0
+    assert order[0]["rice"] == 0
+
+
+def test_outer_try_returns_json_on_unexpected_failure(monkeypatch):
+    """Pre-2.3.2 the tool had inner try/excepts only — uncaught failures
+    bubbled up to the FastMCP harness as the generic 'Error occurred
+    during tool execution' with no diagnostic. The 2.3.2 outer
+    try/except catches every uncaught exception and returns a JSON 500
+    with ``trace_tail`` so the LLM (and the next debugger) sees what
+    actually broke."""
+    class _Boom:
+        # Looks project-shaped enough for the early-validation gate to
+        # pass, but explodes when we walk into list_user_story_attributes.
+        name = "wahed"
+        slug = "wahed"
+        id = 1
+
+        def list_user_story_attributes(self):
+            raise RuntimeError("simulated network failure mid-fetch")
+
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: _Boom())
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+    assert payload["code"] == 500
+    assert "RuntimeError" in payload["error"]
+    assert "simulated network failure mid-fetch" in payload["error"]
+    # Trace tail must be a list of strings (last 5 lines of the
+    # traceback) — NOT a single newline-joined blob, so the harness's
+    # JSON pretty-printer keeps each line readable.
+    assert isinstance(payload["trace_tail"], list)
+    assert len(payload["trace_tail"]) <= 5

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -59,6 +59,11 @@ class _FakeUS:
         self.is_closed = False
 
     def get_attributes(self):
+        # Test hooks: ``_attrs_raises`` flag forces the per-story fetch
+        # to raise, so the partial/total-failure paths in the parallel
+        # fetcher can be exercised without real network conditions.
+        if getattr(self, "_attrs_raises", False):
+            raise RuntimeError("simulated taiga timeout")
         return {"attributes_values": self._attr_values, "version": 1}
 
 
@@ -205,6 +210,76 @@ def test_effort_zero_when_no_points_assigned(monkeypatch, patched_http):
     order = payload["columns_updated"][0]["order"]
     assert order[0]["effort"] == 0
     assert order[0]["rice"] == 0
+
+
+def test_partial_attr_fetch_failure_is_surfaced(monkeypatch, patched_http):
+    """Per Codex/Copilot review on PR #13: a single failing
+    ``get_attributes()`` call previously aborted the whole tool with a
+    500 (loud, intent-preserving). After 2.3.2's parallelization the
+    swallowing exception was hidden — RICE silently defaulted to
+    1×1×1, story sorted to the bottom, caller had no idea. This test
+    locks the new contract: failures are RECORDED in
+    ``attribute_fetch_errors`` of the success payload, the rest of the
+    sort still runs, and the LLM/caller can decide whether to retry."""
+    good = _FakeUS(
+        ref=1, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+    )
+    bad = _FakeUS(
+        ref=2, points={}, total_points=2.0, attr_values={},
+    )
+    bad._attrs_raises = True
+
+    project = _FakeProject(
+        stories=[good, bad],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+    assert payload.get("sorted") is True
+    errors = payload["attribute_fetch_errors"]
+    assert isinstance(errors, list)
+    assert len(errors) == 1
+    assert errors[0]["ref"] == 2
+    assert "RuntimeError" in errors[0]["error"]
+    assert "simulated taiga timeout" in errors[0]["error"]
+    # Both stories still present in the column ordering (the failure
+    # didn't drop the story, just flagged it).
+    refs = {s["ref"] for s in payload["columns_updated"][0]["order"]}
+    assert refs == {1, 2}
+
+
+def test_total_attr_fetch_failure_returns_500(monkeypatch, patched_http):
+    """If EVERY story's attribute fetch fails, RICE scores are
+    uniformly garbage and reordering the Kanban from defaults would be
+    actively harmful. The tool must abort with 500 + the error list,
+    not silently sort by default-1 RICE."""
+    s1 = _FakeUS(
+        ref=1, points={}, total_points=2.0, attr_values={},
+    )
+    s1._attrs_raises = True
+    s2 = _FakeUS(
+        ref=2, points={}, total_points=2.0, attr_values={},
+    )
+    s2._attrs_raises = True
+
+    project = _FakeProject(
+        stories=[s1, s2],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+    assert payload["code"] == 500
+    assert "All per-story custom-attribute fetches failed" in payload["error"]
+    assert len(payload["attribute_fetch_errors"]) == 2
 
 
 def test_outer_try_returns_json_on_unexpected_failure(monkeypatch):


### PR DESCRIPTION
## Summary

Production was hitting `sort_kanban_by_rice_tool` and getting the harness-generic `Error occurred during tool execution` with three different request_ids — no JSON payload, so no diagnostic. K8s pod logs showed: liveness probe on `/mcp/health` timed out (`context deadline exceeded`), kubelet killed the container, the in-flight tool response died with the worker.

Root cause: serial N+1. With ~40 user stories + epics, the tool was making `1 + N + 1 + 2M + 1` HTTP calls (`list_user_stories` + per-story `get_attributes` + `list_epics` + per-epic `get_attributes` + per-epic `list_user_stories` + `list_points`). At ~100ms each that's ~5–10s wall time, well past the FastMCP worker's liveness budget while the worker was holding the request.

## Four fixes

1. **Use `us.total_points` directly.** Taiga's `/userstories?project=X` list endpoint already inlines the per-role-summed effort. Eliminates one HTTP call (`list_points()`) and removes the points-resolution code path that bug-cycled twice in 2.3.0 / 2.3.1.

2. **Group by epic in-memory from inline `us.epics`.** No more per-epic `epic.list_user_stories()` — completion% is computed from the already-loaded stories list. Eliminates `O(epics)` extra HTTP calls.

3. **Parallelize the unavoidable `get_attributes()` calls** with `ThreadPoolExecutor(max_workers=10)`. python-taiga's sync calls are thread-safe for read-side GETs (each thread reuses the underlying `requests.Session`). Wall time on the per-US RICE-attribute fetch drops from `O(N)` to `O(1)`.

4. **Outer `try/except Exception`** wrapping the whole function body so any uncaught failure returns a JSON 500 with `trace_tail` (last 5 traceback lines) instead of bubbling up as the generic "Error occurred during tool execution". This is the diagnostic safety net that was missing — the prod issue was undiagnosable without pod logs.

## What changed

- `langchain_taiga/tools/taiga_tools.py:sort_kanban_by_rice_tool`: rewritten data-fetch section. Sort/group/bulk-update logic at the bottom unchanged but now indented inside the outer try.
- `tests/unit_tests/test_sort_kanban_by_rice_tool.py`: existing tests updated for the new `total_points`-based effort path, plus 2 new tests:
  - `test_effort_zero_when_no_points_assigned` — edge case for unestimated stories (`total_points=None` → effort=0, RICE=0).
  - `test_outer_try_returns_json_on_unexpected_failure` — regression guard so the harness-generic-error issue doesn't recur.
- `pyproject.toml`: 2.3.1 → 2.3.2.

Existing test `test_works_when_developer_role_is_not_id_19` renamed to `test_works_regardless_of_role_id` since the new code doesn't iterate role-IDs at all (was meaningful when 2.3.0 removed the hardcoded "19", less so now that we read `total_points` directly).

## Validation

- `make test`: **173 passed, 1 skipped** (was 171 pre-PR, +2 new tests).
- Probed live `wahed` to confirm the data shape: `/userstories?project=X` does NOT include `attributes_values` inline (so the per-US `get_attributes` is unavoidable, hence the parallelization). It DOES include `total_points`, `epics`, `points`, `status`, `swimlane`, `due_date`, `is_closed` — every other field the tool needs.
- Decided NOT to use raw HTTP: python-taiga's `Resource.get_attributes()` is the cleanest path for the one remaining N+1 step, and `ThreadPoolExecutor` over the python-taiga API is enough.

## Notable risks

- **Behaviour preservation**: same effort semantics as 2.3.1 (sum across computable role assignments), just delegated to Taiga's server-side `total_points` field instead of computed locally. No user-visible change in sort order.
- **Threading**: python-taiga's `Requester` reuses a `requests.Session`, which is thread-safe for read GETs. Write paths are not parallelized, so no risk of concurrent-write races.
- **`max_workers=10`**: deliberate cap to keep load on the Taiga API server bounded. Even on projects with hundreds of stories, total wall time stays under K8s liveness probe budget.

## Test plan

- [x] `make test` (173 passed).
- [x] Outer-try regression locked by `test_outer_try_returns_json_on_unexpected_failure`.
- [ ] Smoke test in prod after merge + deploy: `sort_kanban_by_rice_tool("wahed")` should return JSON cleanly within seconds, regardless of how many user stories `wahed` has. If it still 500s, the JSON now carries the actual cause via `trace_tail`.
