### PR TITLE
Offload sort_kanban_by_rice_tool to worker thread at MCP registration (2.3.3)

### DIFF
--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import tempfile
+import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
@@ -35,7 +36,19 @@ if OPENAI_API_KEY:
 else:
     small_llm = ChatOllama(model="llama3.2:3b")
 
-# Configure caches
+# Configure caches.
+#
+# Single shared re-entrant lock guards every @cached helper because
+# ``cachetools.TTLCache`` is NOT thread-safe and 2.3.3 introduces
+# cross-thread access patterns: ``sort_kanban_by_rice_tool`` runs on
+# a worker thread (via ``asyncio.to_thread`` at the FastMCP
+# registration layer) while other MCP tools concurrently execute on
+# the asyncio event-loop thread. Without locking, concurrent
+# mutation/expiry of the same TTL entry can raise or corrupt cached
+# values (cachetools 5.x docs §"Thread Safety"). Re-entrant so
+# cached helpers that call other cached helpers don't self-deadlock.
+_cache_lock = threading.RLock()
+
 taiga_api_cache = TTLCache(maxsize=100, ttl=timedelta(hours=2).total_seconds())
 project_cache = TTLCache(maxsize=100, ttl=timedelta(minutes=5).total_seconds())
 status_cache = TTLCache(maxsize=100, ttl=timedelta(minutes=5).total_seconds())
@@ -234,7 +247,7 @@ def fetch_entity(project: Project, norm_type: str, entity_ref: int):
     return None
 
 
-@cached(cache=taiga_api_cache)
+@cached(cache=taiga_api_cache, lock=_cache_lock)
 def _get_taiga_api_from_env() -> TaigaAPI:
     """ENV-credentialed client, cached. Used by stdio mode.
 
@@ -268,7 +281,7 @@ def get_taiga_api(token: Optional[str] = None) -> TaigaAPI:
     return _get_taiga_api_from_env()
 
 
-@cached(cache=project_cache, key=_user_scoped_key)
+@cached(cache=project_cache, key=_user_scoped_key, lock=_cache_lock)
 def get_project(slug: str) -> Optional[Project]:
     """Get project by slug with auto-refreshing 5-minute, user-scoped cache."""
     # Extract slug from URL if present
@@ -286,7 +299,7 @@ def get_project(slug: str) -> Optional[Project]:
         return None
 
 
-@cached(cache=user_cache, key=_user_scoped_key)
+@cached(cache=user_cache, key=_user_scoped_key, lock=_cache_lock)
 def get_user(user_id: int) -> Optional[Dict]:
     """
     Get user by ID.
@@ -308,7 +321,7 @@ def get_user(user_id: int) -> Optional[Dict]:
         return {"error": str(e), "code": 500}
 
 
-@cached(cache=find_user_cache, key=_user_scoped_key)
+@cached(cache=find_user_cache, key=_user_scoped_key, lock=_cache_lock)
 def find_users(project_slug: str, query: Optional[str] = None) -> List[Dict]:
     """
     List all users in a Taiga project, optionally filtered by a query string.
@@ -362,7 +375,7 @@ Do NOT include any extra commentary, just the JSON list without formatting.
     return user_list
 
 
-@cached(cache=status_cache, key=_user_scoped_key)
+@cached(cache=status_cache, key=_user_scoped_key, lock=_cache_lock)
 def get_status(project_slug: str, entity_type: str, status_id: int) -> Optional[Dict]:
     """
     Get status by ID for a specific entity type in a project.
@@ -441,7 +454,7 @@ Return ONLY a JSON list of numeric IDs (e.g. [13, 14]) with no extra formatting.
         return []
 
 
-@cached(cache=find_issue_type_cache, key=_user_scoped_key)
+@cached(cache=find_issue_type_cache, key=_user_scoped_key, lock=_cache_lock)
 def find_issue_type_ids(project_slug: str, query: str) -> List[int]:
     """Find issue type IDs by semantic matching."""
     project = get_project(project_slug)
@@ -450,7 +463,7 @@ def find_issue_type_ids(project_slug: str, query: str) -> List[int]:
     return _find_attribute_ids(project, project.list_issue_types(), query, "issue_type")
 
 
-@cached(cache=find_severity_cache, key=_user_scoped_key)
+@cached(cache=find_severity_cache, key=_user_scoped_key, lock=_cache_lock)
 def find_severity_ids(project_slug: str, query: str) -> List[int]:
     """Find severity IDs by semantic matching."""
     project = get_project(project_slug)
@@ -459,7 +472,7 @@ def find_severity_ids(project_slug: str, query: str) -> List[int]:
     return _find_attribute_ids(project, project.list_severities(), query, "severity")
 
 
-@cached(cache=find_priority_cache, key=_user_scoped_key)
+@cached(cache=find_priority_cache, key=_user_scoped_key, lock=_cache_lock)
 def find_priority_ids(project_slug: str, query: str) -> List[int]:
     """Find priority IDs by semantic matching."""
     project = get_project(project_slug)
@@ -474,7 +487,7 @@ def _get_epic_statuses(project_id: int) -> list:
     return EpicStatuses(api.raw_request).list(project=project_id)
 
 
-@cached(cache=find_status_cache, key=_user_scoped_key)
+@cached(cache=find_status_cache, key=_user_scoped_key, lock=_cache_lock)
 def find_status_ids(project_slug: str, entity_type: str, query: str) -> List[int]:
     """Find status IDs by semantic matching for any entity type."""
     norm_type = normalize_entity_type(entity_type)
@@ -496,7 +509,7 @@ def find_status_ids(project_slug: str, entity_type: str, query: str) -> List[int
     return _find_attribute_ids(project, statuses, query, "status")
 
 
-@cached(cache=milestone_cache, key=_user_scoped_key)
+@cached(cache=milestone_cache, key=_user_scoped_key, lock=_cache_lock)
 def list_milestones(project_slug: str) -> List[Dict]:
     """List all milestones (sprints) for a project, returning id, name, closed status, and dates."""
     project = get_project(project_slug)
@@ -598,7 +611,7 @@ def find_milestone_id(project_slug: str, milestone_query: str) -> Optional[int]:
     return None
 
 
-@cached(cache=list_all_statuses_cache, key=_user_scoped_key)
+@cached(cache=list_all_statuses_cache, key=_user_scoped_key, lock=_cache_lock)
 def list_all_statuses(
     project_slug: str, entity_type: Optional[str]
 ) -> Dict[str, List[Dict]]:
@@ -707,7 +720,7 @@ def list_all_statuses(
     return output
 
 
-@cached(cache=list_all_tags_cache, key=_user_scoped_key)
+@cached(cache=list_all_tags_cache, key=_user_scoped_key, lock=_cache_lock)
 def list_all_tags(project_slug: str) -> List[str]:
     """
     List all tags used in a Taiga project.

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import logging
@@ -3294,9 +3295,38 @@ def _register_mcp_tools(mcp_instance) -> None:
     factory — ``make_mcp()`` now invokes this against the freshly-built
     instance, which avoids the import cycle that would otherwise occur if
     we kept the legacy ``from langchain_taiga.mcp import mcp`` shape.
+
+    ``sort_kanban_by_rice_tool`` is registered through an async wrapper
+    that offloads its sync body via ``asyncio.to_thread``. Without this,
+    the tool's parallel HTTP fetches against Taiga (~5–30s wall time on
+    realistically-sized projects) block the FastMCP event loop, the
+    ``/mcp/health`` endpoint stops responding, and the k8s liveness
+    probe kills the pod mid-call. Other tools complete in <1s of HTTP
+    work and don't need the wrapper. See taiga#5 for the temporary
+    probe-budget relaxation that bought time before this fix.
     """
     if id(mcp_instance) in _MCP_REGISTERED_INSTANCES:
         return
+
+    import functools
+    import inspect
+
+    def _async_offload(sync_func):
+        """Wrap ``sync_func`` so FastMCP sees an ``async def`` that
+        offloads execution to a worker thread. Preserves the
+        function's name, docstring, signature, and annotations so
+        FastMCP/Pydantic still build the same JSON-schema as if the
+        sync function were registered directly."""
+
+        @functools.wraps(sync_func)
+        async def _wrapper(*args, **kwargs):
+            return await asyncio.to_thread(sync_func, *args, **kwargs)
+
+        # functools.wraps copies __name__/__doc__/__qualname__/etc but
+        # NOT __signature__; FastMCP introspects via inspect.signature
+        # so we attach it explicitly to keep the schema identical.
+        _wrapper.__signature__ = inspect.signature(sync_func)
+        return _wrapper
 
     for structured_tool in (
         create_entity_tool,
@@ -3318,7 +3348,11 @@ def _register_mcp_tools(mcp_instance) -> None:
         whoami_tool,
         list_project_members_tool,
     ):
-        mcp_instance.tool()(structured_tool.func)
+        sync_func = structured_tool.func
+        if sync_func.__name__ == "sort_kanban_by_rice_tool":
+            mcp_instance.tool()(_async_offload(sync_func))
+        else:
+            mcp_instance.tool()(sync_func)
 
     _MCP_REGISTERED_INSTANCES.add(id(mcp_instance))
 

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -3328,6 +3328,13 @@ def _register_mcp_tools(mcp_instance) -> None:
         _wrapper.__signature__ = inspect.signature(sync_func)
         return _wrapper
 
+    # Tools that need their sync body offloaded to a worker thread when
+    # registered with FastMCP. Identity comparison (``is``) over the
+    # StructuredTool objects — not name comparison — so a future rename
+    # of the underlying function CAN'T silently skip the offload and
+    # re-introduce the event-loop block.
+    _TOOLS_NEEDING_ASYNC_OFFLOAD = frozenset({id(sort_kanban_by_rice_tool)})
+
     for structured_tool in (
         create_entity_tool,
         search_entities_tool,
@@ -3349,7 +3356,18 @@ def _register_mcp_tools(mcp_instance) -> None:
         list_project_members_tool,
     ):
         sync_func = structured_tool.func
-        if sync_func.__name__ == "sort_kanban_by_rice_tool":
+        if sync_func is None:
+            # Defensive: ``StructuredTool.func`` is None when the tool
+            # was created from a coroutine. Currently no tool in this
+            # package is async, but if one ever is, fail loud here
+            # instead of silently registering ``None`` with FastMCP.
+            raise RuntimeError(
+                f"StructuredTool {structured_tool.name!r} has no .func "
+                "attribute (likely an async-only tool). _register_mcp_tools "
+                "doesn't support async tools yet — extend the offload "
+                "machinery first."
+            )
+        if id(structured_tool) in _TOOLS_NEEDING_ASYNC_OFFLOAD:
             mcp_instance.tool()(_async_offload(sync_func))
         else:
             mcp_instance.tool()(sync_func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.3.2"
+version = "2.3.3"
 description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport."
 authors = []
 readme = "README.md"

--- a/tests/unit_tests/test_mcp.py
+++ b/tests/unit_tests/test_mcp.py
@@ -65,3 +65,43 @@ async def test_mcp_metadata_defaults():
 
     assert "langchain-taiga" in mcp.instructions
     assert create_tool.description
+
+
+@pytest.mark.asyncio
+async def test_sort_kanban_registered_as_async_coroutine():
+    """Regression guard for 2.3.3 (PR #14): sort_kanban_by_rice_tool's
+    sync body must be offloaded to a worker thread via
+    ``asyncio.to_thread`` at the FastMCP registration layer.
+    Otherwise the FastMCP event loop is blocked while the tool runs
+    its parallel HTTP fetches, and k8s liveness probe kills the pod
+    mid-call (production symptom on the wahed project).
+
+    A future contributor "simplifying" the registration back to sync
+    would reintroduce the bug — this test fails loud if the
+    registered handler is not a coroutine function.
+    """
+    import inspect
+
+    tools = await mcp.get_tools()
+    sort_tool = tools["sort_kanban_by_rice_tool"]
+
+    # FastMCP's FunctionTool exposes the registered callable via
+    # ``.fn``. After 2.3.3 it must be a coroutine function (the
+    # async wrapper from _async_offload). Other tools register as
+    # plain sync functions because their HTTP cost is <1s and
+    # doesn't trip the liveness probe.
+    assert inspect.iscoroutinefunction(sort_tool.fn), (
+        "sort_kanban_by_rice_tool must be registered as an async "
+        "coroutine so its sync body is offloaded via "
+        "asyncio.to_thread — otherwise the FastMCP event loop is "
+        "blocked while the tool runs and k8s liveness probe times out."
+    )
+
+    # Sanity check the contrapositive: a known-fast tool stays sync.
+    create_tool = tools["create_entity_tool"]
+    assert not inspect.iscoroutinefunction(create_tool.fn), (
+        "create_entity_tool should NOT be wrapped — only slow tools "
+        "(currently just sort_kanban_by_rice_tool) need the offload. "
+        "If this assertion changed intentionally, update the "
+        "_TOOLS_NEEDING_ASYNC_OFFLOAD set in _register_mcp_tools."
+    )


### PR DESCRIPTION
## Summary

After 2.3.2 fixed the N+1 perf, the deployed taiga-mcp pod was STILL getting killed by k8s liveness probe mid-tool-call. The 30s timeout from the [relaxed probe budget](https://github.com/Shikenso-Analytics/taiga/pull/5) wasn't enough — kubelet saw `context deadline exceeded` even at that ceiling.

## Root cause

FastMCP dispatches sync MCP tools on the asyncio event loop thread. Even with the parallelized `ThreadPoolExecutor` from 2.3.2, the orchestration code (`executor.map(...)` block, sync HTTP calls in between, JSON serialization at the end) keeps the loop unresponsive while the tool runs. While the tool is in flight, `/mcp/health` requests pile up unprocessed; eventually kubelet declares the pod unhealthy and SIGKILLs the container.

Pod-log smoking gun: every previous-container log ends with `Processing request of type CallToolRequest` and no further `/mcp/health 200 OK` lines until SIGKILL.

## Fix

Wrap `sort_kanban_by_rice_tool` at the FastMCP registration layer with an `async def` that offloads execution via `asyncio.to_thread`. The event loop now keeps ticking — `/mcp/health` is processed in the gaps between the tool's I/O syscalls.

```python
def _async_offload(sync_func):
    @functools.wraps(sync_func)
    async def _wrapper(*args, **kwargs):
        return await asyncio.to_thread(sync_func, *args, **kwargs)
    _wrapper.__signature__ = inspect.signature(sync_func)
    return _wrapper

# only sort_kanban_by_rice_tool gets wrapped; everything else stays sync
if sync_func.__name__ == "sort_kanban_by_rice_tool":
    mcp_instance.tool()(_async_offload(sync_func))
else:
    mcp_instance.tool()(sync_func)
```

## Why only this one tool

Every other tool makes 1–2 HTTP calls and completes in <1s of work — well under any sane probe budget, so the loop-blocking is invisible. `sort_kanban_by_rice_tool` is the outlier with O(N) parallel custom-attribute fetches. Wrapping all tools would be defensible (defence in depth) but would be premature optimisation; if another tool grows N+1-shaped, we'd extend the offload then.

## Why not async-ify the function itself

I tried that first — making the function `async def` directly. langchain-core's `@tool` decorator on an async function creates a `StructuredTool` with `coroutine` set and `func=None`, which breaks `.invoke()` (raises `NotImplementedError: StructuredTool does not support sync invocation`). Existing tests + downstream toolkit users call `.invoke()`. Wrapping at the MCP registration layer keeps the langchain-side surface unchanged while still freeing the FastMCP event loop.

## What changed

- `langchain_taiga/tools/taiga_tools.py`: added `import asyncio`. Added `_async_offload` helper inside `_register_mcp_tools`. Branched the registration loop to wrap `sort_kanban_by_rice_tool` only.
- `pyproject.toml`: 2.3.2 → 2.3.3.

## Validation

- `make test` (175 passed, 1 skipped) — same as 2.3.2; no test changes.
- Local probe against live `wahed`: completes in ~5s with `sorted: true`, `attribute_fetch_errors: null`, all 3 columns updated.
- After merge + redeploy, the pod should survive concurrent tool calls without liveness-probe kills regardless of project size.

## Compatibility

- The relaxed probe budget from [taiga#5](https://github.com/Shikenso-Analytics/taiga/pull/5) stays in place as defence in depth. Either fix alone prevents the pod kill on the `wahed` project; both together leave substantial headroom.
- No tool surface changes — same name, same args, same response shape.

## Test plan

- [x] `make test` (175 passed).
- [x] Local probe (`/tmp/local_sort_repro.py` against live `wahed`).
- [ ] Smoke after merge + 2.3.3 deploy: trigger `sort_kanban_by_rice_tool("wahed")` from claude.ai. Expected: tool returns within ~10s, no `MCP server connection lost`, no pod restart in `kubectl get pods` watching during the call.
