### PR TITLE
Skip closed status columns + return status_name in sort_kanban_by_rice_tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 18 tools:
 - **`list_custom_attributes_tool`**: Lists custom-attribute *definitions* for a project + entity type.
 - **`set_custom_attributes_tool`**: Sets custom-attribute values on a user story, task or issue.
 - **`get_custom_attributes_tool`**: Reads custom-attribute values from a user story, task or issue.
-- **`sort_kanban_by_rice_tool`**: Re-orders Kanban swimlanes using a RICE-style score.
+- **`sort_kanban_by_rice_tool`**: Re-orders Kanban swimlanes using a RICE-style score. Closed status columns (Done, Cancelled, …) are skipped — re-ranking already-completed work has no value. Each entry in `columns_updated` carries `status_name` alongside `status_id` so consumers don't need to round-trip through Taiga to translate the id.
 - **`set_userstory_points_tool`**: Sets Taiga story points on a user story for one or more roles (Developer, UX, Design, …). Resolves role names + point values to internal IDs at runtime so it adapts to per-project scales. The only programmatic path to set the field that `sort_kanban_by_rice_tool` reads as effort. The target role must be configured as **computable** in the project (Taiga admin → Members → Roles → "Compute story points for this role"); non-computable roles are rejected upfront with a 400 + `non_computable_roles` diagnostic, instead of letting Taiga's PATCH endpoint return its cryptic `Invalid role id` server-side rejection (which would otherwise surface as a generic 500 via this tool's exception wrapper).
 - **`list_wiki_pages_tool`**: Lists wiki pages in a project.
 - **`get_wiki_page_tool`**: Reads a wiki page by slug.

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2526,6 +2526,10 @@ def sort_kanban_by_rice_tool(
     RICE = (Reach × Impact × Confidence) / Effort
     Final Priority = RICE × Epic Multiplicator × Completion Bonus × Urgency Multiplier
 
+    Closed status columns (Done, Cancelled, …) are skipped — re-ranking
+    already-completed work has no value. Each entry in ``columns_updated``
+    carries the resolved ``status_name`` alongside ``status_id``.
+
     Completion Bonus rewards nearly-finished epics ("finish what you started"):
     Formula: 1.0 + 0.5 × (closed_stories / total_stories)²
     - 0% complete: 1.00 (no bonus)

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2786,6 +2786,38 @@ async def _sort_kanban_async_impl(
             key = (s["status_id"], s["swimlane_id"])
             grouped[key].append(s)
 
+        # Build a status-id → status-dict lookup. The same call serves
+        # the skip-closed filter below AND the ``status_name``
+        # augmentation in section 9. ``list_all_statuses`` is cached
+        # for 5 min (``list_all_statuses_cache``), so back-to-back sort
+        # calls share it. A failure here intentionally bubbles to the
+        # outer try/except — silently sorting closed columns on a
+        # transient failure would defeat the point of this filter.
+        status_by_id: Dict[int, Dict[str, Any]] = {
+            s["id"]: s
+            for s in list_all_statuses(project_slug, "us").get(
+                "us_statuses", []
+            )
+        }
+
+        # Drop groups whose status is closed (Done, Cancelled, ...).
+        # Re-ranking completed work has no value and would generate a
+        # redundant bulk-update POST per closed column. Orphan
+        # status_ids — present in ``grouped`` but absent from
+        # ``status_by_id`` (e.g. after an admin renamed the status
+        # mid-cache-window) — are FAIL-OPEN: sorted normally rather
+        # than dropped, so we never silently lose work on a transient
+        # mismatch. The matching ``status_name`` falls back to None in
+        # section 9.
+        grouped = defaultdict(
+            list,
+            {
+                (sid, swimlane): rows
+                for (sid, swimlane), rows in grouped.items()
+                if not status_by_id.get(sid, {}).get("is_closed", False)
+            },
+        )
+
         for key in grouped:
             stories = grouped[key]
             stories.sort(key=lambda x: x["final_priority"], reverse=descending)

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2630,20 +2630,28 @@ async def _sort_kanban_async_impl(
         # ``points``, ``total_points``, ``epics``, ``status``, ``swimlane``,
         # ``due_date``, ``is_closed`` — so we don't need any per-US calls
         # for those, only for the custom-attribute values (RICE).
-        stories = list(project.list_user_stories())
+        all_stories = list(project.list_user_stories())
 
-        # Drop closed stories BEFORE the per-US async fetch. ``us.is_closed``
-        # mirrors whether the story's status has ``is_closed=True`` (Taiga
-        # syncs the per-story flag from the per-status flag). Skipping these
-        # here avoids ~N redundant ``custom-attributes-values`` GETs on
-        # closed-heavy boards AND prevents the section-3 total-failure
-        # guard from firing falsely on a closed-only board during a
-        # transient attr-fetch outage. The section-7 status_by_id filter
-        # below still runs as defense-in-depth (handles the rare case
-        # where ``us.is_closed`` and ``status.is_closed`` disagree, e.g.
-        # right after an admin toggles a status's closed flag and the
-        # per-story field hasn't caught up yet).
-        stories = [us for us in stories if not getattr(us, "is_closed", False)]
+        # ``stories`` is the working list for the per-US async fetch and
+        # the eventual sort/POST loop — closed stories are dropped here
+        # to (a) avoid ~N redundant ``custom-attributes-values`` GETs
+        # on closed-heavy boards and (b) prevent the section-3
+        # total-failure guard from firing falsely on a closed-only
+        # board during a transient attr-fetch outage. The section-7
+        # ``status_by_id`` filter below still runs as defense-in-depth
+        # (handles the rare case where ``us.is_closed`` and
+        # ``status.is_closed`` disagree, e.g. right after an admin
+        # toggles a status's closed flag and the per-story field hasn't
+        # caught up yet).
+        #
+        # ``all_stories`` is preserved for section-4 epic-completion
+        # math: closed stories MUST count toward their epic's
+        # completion_pct, otherwise an 80%-complete epic looks like 0%
+        # to its remaining open stories and the documented "finish what
+        # you started" boost (1.0–1.5×) is silently disabled.
+        stories = [
+            us for us in all_stories if not getattr(us, "is_closed", False)
+        ]
 
         # --- 3. Async-parallel per-US custom-attribute fetch.
         # Per-story failures are RECORDED in ``attribute_fetch_errors``
@@ -2686,8 +2694,16 @@ async def _sort_kanban_async_impl(
         # Pre-2.3.2 the per-epic ``epic.list_user_stories()`` was an
         # additional N+1 over epics; this groups in-memory from the
         # already-fetched stories list, no extra HTTP.
+        #
+        # Iterates ``all_stories`` (NOT the closed-filtered ``stories``)
+        # so that closed stories still count toward their epic's
+        # completion ratio. Filtering them out here would zero the
+        # closed-count for any epic that has both open and closed work
+        # → ``completion_pct = 0`` → ``completion_bonus = 1.0`` → the
+        # documented "finish what you started" boost (1.0–1.5×) would
+        # silently disappear, regressing RICE order for active stories.
         epic_to_stories: defaultdict = defaultdict(list)
-        for us in stories:
+        for us in all_stories:
             for e in (getattr(us, "epics", None) or []):
                 epic_id = (
                     e.get("id") if isinstance(e, dict) else getattr(e, "id", None)

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2884,6 +2884,9 @@ async def _sort_kanban_async_impl(
                 results.append(
                     {
                         "status_id": status_id,
+                        "status_name": status_by_id.get(status_id, {}).get(
+                            "name"
+                        ),
                         "swimlane_id": swimlane_id,
                         "success": resp.status_code == 200,
                         "order": [
@@ -2908,6 +2911,9 @@ async def _sort_kanban_async_impl(
                 results.append(
                     {
                         "status_id": status_id,
+                        "status_name": status_by_id.get(status_id, {}).get(
+                            "name"
+                        ),
                         "swimlane_id": swimlane_id,
                         "success": False,
                         "error": str(e),

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2632,6 +2632,19 @@ async def _sort_kanban_async_impl(
         # for those, only for the custom-attribute values (RICE).
         stories = list(project.list_user_stories())
 
+        # Drop closed stories BEFORE the per-US async fetch. ``us.is_closed``
+        # mirrors whether the story's status has ``is_closed=True`` (Taiga
+        # syncs the per-story flag from the per-status flag). Skipping these
+        # here avoids ~N redundant ``custom-attributes-values`` GETs on
+        # closed-heavy boards AND prevents the section-3 total-failure
+        # guard from firing falsely on a closed-only board during a
+        # transient attr-fetch outage. The section-7 status_by_id filter
+        # below still runs as defense-in-depth (handles the rare case
+        # where ``us.is_closed`` and ``status.is_closed`` disagree, e.g.
+        # right after an admin toggles a status's closed flag and the
+        # per-story field hasn't caught up yet).
+        stories = [us for us in stories if not getattr(us, "is_closed", False)]
+
         # --- 3. Async-parallel per-US custom-attribute fetch.
         # Per-story failures are RECORDED in ``attribute_fetch_errors``
         # rather than swallowed: a missing reach/impact/confidence

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2826,30 +2826,42 @@ async def _sort_kanban_async_impl(
         # calls share it. A failure here intentionally bubbles to the
         # outer try/except — silently sorting closed columns on a
         # transient failure would defeat the point of this filter.
-        status_by_id: Dict[int, Dict[str, Any]] = {
-            s["id"]: s
-            for s in list_all_statuses(project_slug, "us").get(
-                "us_statuses", []
-            )
-        }
+        #
+        # Short-circuit on empty ``grouped``: if the board has no
+        # stories left to sort (closed-only project, or every story
+        # filtered out earlier), there's nothing to filter or augment,
+        # so we skip the ``list_all_statuses`` call entirely. Without
+        # this, an empty/closed-only board on a transient
+        # statuses-endpoint outage would surface as a 500 even though
+        # the right answer is "nothing to sort". Section 9's per-column
+        # loop also doesn't run on empty ``grouped``, so leaving
+        # ``status_by_id`` as ``{}`` is safe.
+        status_by_id: Dict[int, Dict[str, Any]] = {}
+        if grouped:
+            status_by_id = {
+                s["id"]: s
+                for s in list_all_statuses(project_slug, "us").get(
+                    "us_statuses", []
+                )
+            }
 
-        # Drop groups whose status is closed (Done, Cancelled, ...).
-        # Re-ranking completed work has no value and would generate a
-        # redundant bulk-update POST per closed column. Orphan
-        # status_ids — present in ``grouped`` but absent from
-        # ``status_by_id`` (e.g. after an admin renamed the status
-        # mid-cache-window) — are FAIL-OPEN: sorted normally rather
-        # than dropped, so we never silently lose work on a transient
-        # mismatch. The matching ``status_name`` falls back to None in
-        # section 9.
-        grouped = defaultdict(
-            list,
-            {
-                (sid, swimlane): rows
-                for (sid, swimlane), rows in grouped.items()
-                if not status_by_id.get(sid, {}).get("is_closed", False)
-            },
-        )
+            # Drop groups whose status is closed (Done, Cancelled, ...).
+            # Re-ranking completed work has no value and would generate a
+            # redundant bulk-update POST per closed column. Orphan
+            # status_ids — present in ``grouped`` but absent from
+            # ``status_by_id`` (e.g. after an admin renamed the status
+            # mid-cache-window) — are FAIL-OPEN: sorted normally rather
+            # than dropped, so we never silently lose work on a transient
+            # mismatch. The matching ``status_name`` falls back to None
+            # in section 9.
+            grouped = defaultdict(
+                list,
+                {
+                    (sid, swimlane): rows
+                    for (sid, swimlane), rows in grouped.items()
+                    if not status_by_id.get(sid, {}).get("is_closed", False)
+                },
+            )
 
         for key in grouped:
             stories = grouped[key]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.3.4"
+version = "2.4.0"
 description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport."
 authors = []
 readme = "README.md"

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -658,6 +658,67 @@ def test_response_includes_status_name(monkeypatch, patched_http, respx_mock):
     assert cols[0]["status_name"] == "New"
 
 
+def test_closed_stories_skip_per_us_attr_fetch(
+    monkeypatch, patched_http, respx_mock
+):
+    """Codex P2 regression guard for 2.4.0: stories whose
+    ``us.is_closed`` flag is True MUST be filtered out BEFORE the
+    section-3 per-US async attr fetch — not only at the section-7
+    status_by_id filter. Without the early filter, closed-heavy
+    boards waste one ``custom-attributes-values`` GET per closed
+    story, AND a closed-only board can hit the section-3
+    total-failure guard ("All per-story custom-attribute fetches
+    failed; cannot compute RICE scores reliably") on a transient
+    attr-fetch outage even though the right answer is "nothing to
+    sort, no failure".
+
+    Test mechanic: register the closed story's attr route to return
+    HTTP 500. If the early filter is in place, the route is NEVER
+    called and ``attribute_fetch_errors`` stays None. If a future
+    contributor removes the early filter, the 500 lands in
+    ``attribute_fetch_errors`` and this test flips red.
+    """
+    open_story = _FakeUS(
+        ref=1, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=100,
+    )
+    closed_story = _FakeUS(
+        ref=2, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=200,
+    )
+    closed_story.is_closed = True
+
+    project = _FakeProject(
+        stories=[open_story, closed_story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+        us_statuses=[
+            _FakeStatus(100, "New", is_closed=False),
+            _FakeStatus(200, "Done", is_closed=True),
+        ],
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(
+        respx_mock, [open_story, closed_story], raise_refs={2}
+    )
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+
+    assert payload.get("sorted") is True
+    # The closed story's would-be 500 was never fetched → no errors.
+    assert payload["attribute_fetch_errors"] is None
+    # Only the open column appears (defense-in-depth: section-7 filter
+    # would also drop the closed column even if the early filter
+    # somehow let the closed story through).
+    cols = payload["columns_updated"]
+    assert len(cols) == 1
+    assert cols[0]["status_id"] == 100
+
+
 def test_orphan_status_id_is_not_dropped(
     monkeypatch, patched_http, respx_mock
 ):

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -621,6 +621,36 @@ def test_skips_closed_status_columns(monkeypatch, respx_mock):
     assert len(bulk_calls) == 1
 
 
+def test_response_includes_status_name(monkeypatch, patched_http, respx_mock):
+    """Per-column entry in ``columns_updated`` must include a
+    ``status_name`` string sourced from the same ``list_all_statuses``
+    call as the closed-skip filter. Pre-2.4.0 only ``status_id`` was
+    returned — consumers had to round-trip through Taiga to translate.
+    """
+    story = _FakeUS(
+        ref=1, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=100,
+    )
+    project = _FakeProject(
+        stories=[story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+        us_statuses=[_FakeStatus(100, "New", is_closed=False)],
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(respx_mock, [story])
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+
+    cols = payload["columns_updated"]
+    assert len(cols) == 1
+    assert cols[0]["status_id"] == 100
+    assert cols[0]["status_name"] == "New"
+
+
 def test_attr_def_cache_skips_second_discovery(
     monkeypatch, patched_http, respx_mock
 ):

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -563,6 +563,64 @@ def test_missing_taiga_url_config_returns_clear_error(
     assert "TAIGA_URL" in payload["error"]
 
 
+def test_skips_closed_status_columns(monkeypatch, respx_mock):
+    """Closed status columns (Done, Cancelled, ...) MUST be filtered out
+    of the sort. Re-ranking already-completed work has no business
+    value and produces redundant ``bulk_update_kanban_order`` POSTs
+    against Taiga. New default in 2.4.0; not opt-out-able.
+    """
+    open_story = _FakeUS(
+        ref=1, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=100,  # open status id
+    )
+    closed_story = _FakeUS(
+        ref=2, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=200,  # closed status id
+    )
+    project = _FakeProject(
+        stories=[open_story, closed_story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+        us_statuses=[
+            _FakeStatus(100, "New", is_closed=False),
+            _FakeStatus(200, "Done", is_closed=True),
+        ],
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(respx_mock, [open_story, closed_story])
+
+    # Count how many times the bulk-update POST is hit. Replaces the
+    # ``patched_http`` fixture's lambda so we can assert call count
+    # without re-running its setup.
+    bulk_calls = []
+    fake_response = SimpleNamespace(status_code=200, json=lambda: {})
+
+    def _record_post(*args, **kwargs):
+        bulk_calls.append((args, kwargs))
+        return fake_response
+
+    monkeypatch.setattr(taiga_tools.requests, "post", _record_post)
+    monkeypatch.setattr(
+        taiga_tools, "get_taiga_api",
+        lambda token=None: SimpleNamespace(token="fake-token"),
+    )
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+
+    assert payload.get("sorted") is True
+    cols = payload["columns_updated"]
+    # Only the open column was sorted.
+    assert len(cols) == 1
+    assert cols[0]["status_id"] == 100
+    # Bulk-update POST hit exactly once (no redundant call for the
+    # closed column).
+    assert len(bulk_calls) == 1
+
+
 def test_attr_def_cache_skips_second_discovery(
     monkeypatch, patched_http, respx_mock
 ):

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -719,6 +719,77 @@ def test_closed_stories_skip_per_us_attr_fetch(
     assert cols[0]["status_id"] == 100
 
 
+def test_closed_stories_still_count_toward_epic_completion(
+    monkeypatch, patched_http, respx_mock
+):
+    """Codex P1 regression guard for 2.4.0: when the closed-story
+    early filter (``test_closed_stories_skip_per_us_attr_fetch``) was
+    introduced, an earlier draft filtered closed stories out of
+    ``all_stories`` entirely — which broke section-4 epic-completion
+    math because the remaining open stories' epic now showed
+    ``closed_stories=0`` even on a 50%-done epic. That zeroed
+    ``completion_pct`` and silently disabled the documented
+    ``1.0 + 0.5 × pct²`` "finish what you started" boost.
+
+    Final 2.4.0 design: keep ``all_stories`` (unfiltered) for the
+    section-4 epic_to_stories build; the closed-filter only narrows
+    ``stories`` (used by section-3 async fetch + section-7 sort/POST).
+
+    Test mechanic: 1 epic with 1 closed + 1 open story. The open
+    story's ``columns_updated[i]["order"][0]`` row must report
+    ``completion_pct == 50`` (round of 0.5 × 100) and
+    ``completion_bonus == 1.12`` (1.0 + 0.5 × 0.5² = 1.125, then
+    Python's banker's-rounding ``round(1.125, 2) == 1.12``; the
+    README's "50% → 1.13" value is a documentation rounding, not the
+    runtime float). If a future contributor moves the closed-filter
+    back above the epic_to_stories build, both values flip to 0 and
+    1.0 and this test fails loudly.
+    """
+    open_story = _FakeUS(
+        ref=1, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=100,
+    )
+    open_story.epics = [{"id": 42, "ref": 50}]
+
+    closed_story = _FakeUS(
+        ref=2, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=200,
+    )
+    closed_story.epics = [{"id": 42, "ref": 50}]
+    closed_story.is_closed = True
+
+    project = _FakeProject(
+        stories=[open_story, closed_story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+        us_statuses=[
+            _FakeStatus(100, "New", is_closed=False),
+            _FakeStatus(200, "Done", is_closed=True),
+        ],
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(respx_mock, [open_story, closed_story])
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+
+    # Top-level epic_completions reports the 50% ratio for epic 42.
+    assert payload["epic_completions"]["42"] == 50
+
+    # The open column has the open story; its per-row completion math
+    # MUST reflect the closed story's contribution.
+    cols = payload["columns_updated"]
+    assert len(cols) == 1
+    assert cols[0]["status_id"] == 100
+    open_row = cols[0]["order"][0]
+    assert open_row["ref"] == 1
+    assert open_row["completion_pct"] == 50
+    assert open_row["completion_bonus"] == 1.12
+
+
 def test_orphan_status_id_is_not_dropped(
     monkeypatch, patched_http, respx_mock
 ):

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -5,11 +5,18 @@ History (the contract these tests lock):
   every role's points.
 - 2.3.2: per-US custom-attribute fetch parallelised via
   ThreadPoolExecutor; total-failure guard + ``attribute_fetch_errors``.
-- 2.3.4 (this file): fetcher migrated from ThreadPoolExecutor + python-
-  taiga ``us.get_attributes()`` to ``httpx.AsyncClient`` + ``asyncio.gather``,
+- 2.3.4: fetcher migrated from ThreadPoolExecutor + python-taiga
+  ``us.get_attributes()`` to ``httpx.AsyncClient`` + ``asyncio.gather``,
   and project/epic discovery cached in module-level TTL caches. Tests
   now mock httpx via ``respx_mock`` instead of stubbing the per-instance
   ``get_attributes`` method, which is no longer called.
+- 2.4.0: closed-status columns are dropped before the bulk-update
+  POST; ``columns_updated`` entries gain ``status_name``. Open-column
+  sort behaviour MUST stay byte-identical for the 2.3.0/2.3.2/2.3.4
+  contract — ``test_effort_takes_us_total_points``,
+  ``test_works_regardless_of_role_id``, and
+  ``test_partial_attr_fetch_failure_is_surfaced`` are the explicit
+  regression guards.
 """
 
 import json

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -67,6 +67,24 @@ class _FakePoint:
         self.value = value
 
 
+class _FakeStatus:
+    """Mirrors the python-taiga UserStoryStatus fields the tool reads.
+
+    ``list_all_statuses(slug, "us")`` calls ``project.list_user_story_statuses()``
+    and projects each status via ``{**status.to_dict(), "id": status.id}``.
+    Matching the same shape lets the production helper consume our fakes
+    without modification.
+    """
+
+    def __init__(self, sid, name, is_closed=False):
+        self.id = sid
+        self.name = name
+        self.is_closed = is_closed
+
+    def to_dict(self):
+        return {"id": self.id, "name": self.name, "is_closed": self.is_closed}
+
+
 class _FakeUS:
     """Mirrors the python-taiga UserStory fields the tool reads.
 
@@ -94,16 +112,33 @@ class _FakeProject:
     name = "Test"
     id = 7
 
-    def __init__(self, stories, roles, points, us_attrs, epic_attrs=None):
+    def __init__(
+        self,
+        stories,
+        roles,
+        points,
+        us_attrs,
+        epic_attrs=None,
+        us_statuses=None,
+    ):
         self._stories = stories
         self._roles = roles
         self._points = points
         self._us_attrs = us_attrs
         self._epic_attrs = epic_attrs or []
+        # Default: a single open status matching the existing
+        # _FakeUS(status=100) default. Tests that need closed columns
+        # or custom names override via ``us_statuses=...``.
+        self._us_statuses = (
+            us_statuses
+            if us_statuses is not None
+            else [_FakeStatus(100, "New", is_closed=False)]
+        )
         # Counters so cache-hit tests can assert no second fetch.
         self.list_user_story_attributes_calls = 0
         self.list_epic_attributes_calls = 0
         self.list_epics_calls = 0
+        self.list_user_story_statuses_calls = 0
 
     def list_user_stories(self):
         return self._stories
@@ -125,6 +160,10 @@ class _FakeProject:
     def list_epics(self):
         self.list_epics_calls += 1
         return []
+
+    def list_user_story_statuses(self):
+        self.list_user_story_statuses_calls += 1
+        return self._us_statuses
 
 
 def _register_us_attr_routes(respx_mock, stories, *, raise_refs=()):

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -39,16 +39,19 @@ def fake_env_keys(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def clear_sort_caches():
-    """Reset the 2.3.4 sort-tool attr-def cache between tests.
+    """Reset the sort-tool TTL caches between tests.
 
-    ``sort_attr_def_cache`` is keyed by ``(user_scope, project_slug)``
-    with a 5-min TTL. Without this fixture, the second test using the
-    same project_slug would hit a stale cached entry from the previous
-    test's monkeypatched ``get_project`` and silently use the wrong
-    attribute IDs. Per-epic Multiplicator values are intentionally
-    *not* cached (see the module-level comment).
+    Both ``sort_attr_def_cache`` (5-min TTL, project-level RICE attr
+    discovery) and ``list_all_statuses_cache`` (5-min TTL, project
+    status definitions) are keyed by ``(user_scope, project_slug)``.
+    Without this fixture, the second test using the same project_slug
+    would hit a stale cached entry from the previous test's
+    monkeypatched ``get_project`` and silently use the wrong attribute
+    or status IDs. Per-epic Multiplicator values are intentionally
+    *not* cached (see the module-level comment in taiga_tools.py).
     """
     taiga_tools.sort_attr_def_cache.clear()
+    taiga_tools.list_all_statuses_cache.clear()
     yield
 
 

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -48,14 +48,16 @@ def fake_env_keys(monkeypatch):
 def clear_sort_caches():
     """Reset the sort-tool TTL caches between tests.
 
-    Both ``sort_attr_def_cache`` (5-min TTL, project-level RICE attr
-    discovery) and ``list_all_statuses_cache`` (5-min TTL, project
-    status definitions) are keyed by ``(user_scope, project_slug)``.
-    Without this fixture, the second test using the same project_slug
-    would hit a stale cached entry from the previous test's
-    monkeypatched ``get_project`` and silently use the wrong attribute
-    or status IDs. Per-epic Multiplicator values are intentionally
-    *not* cached (see the module-level comment in taiga_tools.py).
+    ``sort_attr_def_cache`` (5-min TTL, project-level RICE attr
+    discovery) is keyed by ``(user_scope, project_slug)``;
+    ``list_all_statuses_cache`` (5-min TTL, project status definitions)
+    is keyed by ``(user_scope, project_slug, entity_type)`` because the
+    helper takes both args. Without this fixture, the second test using
+    the same project_slug would hit a stale cached entry from the
+    previous test's monkeypatched ``get_project`` and silently use the
+    wrong attribute or status IDs. Per-epic Multiplicator values are
+    intentionally *not* cached (see the module-level comment in
+    taiga_tools.py).
     """
     taiga_tools.sort_attr_def_cache.clear()
     taiga_tools.list_all_statuses_cache.clear()
@@ -788,6 +790,60 @@ def test_closed_stories_still_count_toward_epic_completion(
     assert open_row["ref"] == 1
     assert open_row["completion_pct"] == 50
     assert open_row["completion_bonus"] == 1.12
+
+
+def test_closed_only_board_skips_list_all_statuses_call(
+    monkeypatch, patched_http, respx_mock
+):
+    """Copilot regression guard for 2.4.0: when every story on the
+    board is closed (or the board has no stories at all), the section-7
+    block must NOT call ``list_all_statuses`` — there's nothing to
+    filter or augment, so the cached fetch is wasted work and a
+    transient outage on the statuses endpoint would surface as a 500
+    on an otherwise no-op sort.
+
+    Test mechanic: a single closed story that the early filter drops →
+    ``stories`` (and therefore ``grouped``) ends up empty. We
+    monkey-patch ``list_all_statuses`` to record calls; if the
+    short-circuit works, it's never called.
+    """
+    closed_story = _FakeUS(
+        ref=1, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=200,
+    )
+    closed_story.is_closed = True
+
+    project = _FakeProject(
+        stories=[closed_story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+        us_statuses=[_FakeStatus(200, "Done", is_closed=True)],
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(respx_mock, [closed_story])
+
+    statuses_calls = []
+
+    def _record_statuses_call(slug, entity_type):
+        statuses_calls.append((slug, entity_type))
+        return {"us_statuses": []}
+
+    monkeypatch.setattr(taiga_tools, "list_all_statuses", _record_statuses_call)
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+
+    assert payload.get("sorted") is True
+    # No columns to update on a closed-only board.
+    assert payload["columns_updated"] == []
+    # Critical: the short-circuit must skip the statuses call entirely.
+    assert statuses_calls == [], (
+        "list_all_statuses was called on an empty/closed-only board. "
+        "The 2.4.0 short-circuit should skip the call when ``grouped`` "
+        "is empty — see the section-7 ``if grouped:`` guard."
+    )
 
 
 def test_orphan_status_id_is_not_dropped(

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -651,6 +651,45 @@ def test_response_includes_status_name(monkeypatch, patched_http, respx_mock):
     assert cols[0]["status_name"] == "New"
 
 
+def test_orphan_status_id_is_not_dropped(
+    monkeypatch, patched_http, respx_mock
+):
+    """A story whose ``status`` references an id absent from
+    ``us_statuses`` (orphan — possible after an admin renames or
+    deletes a status mid-cache-window) MUST be sorted normally, not
+    dropped. Skip-closed semantics fail OPEN: treat the unknown
+    status as not-closed rather than silently losing work. The
+    matching ``status_name`` falls back to None to be honest about
+    the lookup miss.
+    """
+    story = _FakeUS(
+        ref=1, points={}, total_points=2.0,
+        attr_values={"1": 5, "2": 5, "3": 5},
+        status=999,  # orphan: not present in us_statuses
+    )
+    project = _FakeProject(
+        stories=[story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_baseline_attrs(),
+        us_statuses=[_FakeStatus(100, "New", is_closed=False)],
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(respx_mock, [story])
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+
+    cols = payload["columns_updated"]
+    # Orphan column was sorted, not dropped.
+    assert len(cols) == 1
+    assert cols[0]["status_id"] == 999
+    # status_name is honest about the lookup miss.
+    assert cols[0]["status_name"] is None
+    # The story is in the order array.
+    assert {row["ref"] for row in cols[0]["order"]} == {1}
+
+
 def test_attr_def_cache_skips_second_discovery(
     monkeypatch, patched_http, respx_mock
 ):


### PR DESCRIPTION
## Summary

Two semantically-aligned changes to `sort_kanban_by_rice_tool` shipping together as 2.4.0. Both are powered by a single `list_all_statuses(project_slug, "us")` call (a cached helper, 5-min TTL), so they cost zero additional HTTP work when bundled.

1. **Skip closed-status columns by default.** The tool no longer re-sorts "Done"/"Cancelled" columns. Re-ranking already-completed work has no business value and produces redundant `bulk_update_kanban_order` POSTs against Taiga. Two-stage filter:
   - **Early** (right after `project.list_user_stories()`): drop stories where `us.is_closed=True`. Saves a per-US `custom-attributes-values` GET per closed story on closed-heavy boards AND prevents the section-3 total-failure guard from firing falsely on a closed-only board during a transient attr-fetch outage.
   - **Late** (right before the section-7 sort loop): drop groups whose status `is_closed=True` per the `status_by_id` lookup. Defense-in-depth — catches the rare case where `us.is_closed` and `status.is_closed` disagree (e.g. right after an admin toggles a status's closed flag and the per-story field hasn't caught up yet).
2. **Return `status_name` per column.** Each `columns_updated` entry (success and failure paths) gains a `status_name` string sourced from the same `status_by_id` lookup. Pre-2.4.0 only `status_id` was returned — consumers had to round-trip through Taiga to translate.

**Orphan handling**: status_ids present in `grouped` but absent from `status_by_id` (e.g. after admin renames a status mid-cache-window) fail OPEN: sorted normally, `status_name=None`. Locked by `test_orphan_status_id_is_not_dropped`.

**Out of scope** (deferred per spec): RICE=0 column filter; `include_closed=True` opt-out parameter; status `color` field; `total_stories`/`deadline_stories` rescoping; performance batching of N+1 calls.

## Why semver minor

Skip-closed is a default behavior change visible in the response shape, even though no public-API contract is broken (existing keys preserved; only added keys + dropped rows in `columns_updated`). Callers that iterated `columns_updated` to count closed-column work will see the count drop.

## Test plan

- [x] `make test` (full unit suite — 184 passed, 1 skipped; +4 new tests vs 2.3.4 baseline)
- [x] Pre-PR Codex review (gpt-5.5 xhigh normal, 1 P2 finding addressed: closed-story early filter)
- [x] Whole-branch reviewer agent (no Critical/Important; 2 trivial Minor only)
- [ ] Live smoke test on `wahed` project after Helm bump in `taiga` repo lands 2.4.0

## Test coverage added

- `test_skips_closed_status_columns` — closed column filtered out, exactly one bulk-update POST
- `test_response_includes_status_name` — `status_name == "New"` on the column entry
- `test_orphan_status_id_is_not_dropped` — orphan column sorted normally, `status_name=None`
- `test_closed_stories_skip_per_us_attr_fetch` — closed story's would-be-500 attr route is never called (Codex P2 regression guard)

The 2.3.0/2.3.2/2.3.4 regression guards (`test_effort_takes_us_total_points`, `test_works_regardless_of_role_id`, `test_partial_attr_fetch_failure_is_surfaced`) all pass unchanged — open-column behavior is byte-identical.

Codex-Review: gpt-5.5 xhigh normal, 1 finding addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)