### PR TITLE
OAuth refresh tokens with rotation + reuse-detection (2.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,12 @@ langchain-taiga-mcp-remote
 The server speaks MCP over the streamable-HTTP transport at the URL given by `TAIGA_MCP_BASE_URL` and implements:
 
 - **OAuth 2.1 + PKCE (S256)** — `/authorize`, `/token`
+- **OAuth 2.1 refresh-token rotation with reuse-detection** (2.5.0+) — connected MCP clients (claude.ai, VSCode, Claude Desktop) stay authenticated across hours without forcing the user back through the OAuth flow. Each refresh rotates the token; a replayed refresh token revokes the entire token family per OAuth 2.1 best practice for public clients.
 - **RFC 7591 Dynamic Client Registration** — `/register`
 - **RFC 8414 / RFC 9728 discovery docs** — `/.well-known/oauth-authorization-server[/<mcp-path>]` and `/.well-known/oauth-protected-resource[/<mcp-path>]`
 - **A login form** at `<mcp-path>/oauth/login` where each user signs in with their own Taiga credentials. The Taiga JWT is then carried per-request via the MCP `AccessToken` claims and used by every tool call — so two users connected to the same server see only their own projects.
 
-OAuth state lives in-process (per-pod in-memory dict). For production, run a single replica; users re-authorize after a restart.
+OAuth state lives in-process (per-pod in-memory dict). For production, run a single replica; users re-authorize after a Helm deploy or pod restart (refresh tokens are wiped along with everything else).
 
 #### Connecting clients to a remote server
 

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -424,8 +424,22 @@ class TaigaOAuthProvider(OAuthProvider):
     async def load_refresh_token(
         self, client: OAuthClientInformationFull, refresh_token: str
     ) -> Optional[RefreshToken]:
-        # v1 doesn't issue refresh tokens; claude.ai falls back to re-OAuth on expiry.
-        return None
+        """Lookup a refresh token by string and return the RefreshToken model.
+
+        Returns rotated_out records too — the FastMCP layer routes them through
+        to exchange_refresh_token where reuse-detection fires. Cross-client
+        presentations short-circuit to None here (mcp-sdk also enforces this
+        before reaching exchange_refresh_token in production).
+        """
+        record = await self._store.lookup_refresh_token(refresh_token)
+        if record is None or record.client_id != client.client_id:
+            return None
+        return RefreshToken(
+            token=record.token,
+            client_id=record.client_id,
+            scopes=list(record.scopes),
+            expires_at=int(record.expires_at.timestamp()),
+        )
 
     async def exchange_refresh_token(
         self,

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -467,40 +467,43 @@ class TaigaOAuthProvider(OAuthProvider):
     ) -> OAuthToken:
         """Exchange a refresh token for a new access+refresh pair.
 
+        Cascade-first ordering (Codex P2 fix): validate + cascade BEFORE
+        consuming the MCP refresh token. A transient Taiga failure
+        (5xx, ReadTimeout, malformed-200) therefore leaves the refresh
+        token usable for retry rather than forcing a full re-OAuth.
+
         Flow:
-        1. Atomic consume_refresh_token routes to one of four branches.
-        2. ``not_found`` / ``expired`` → invalid_grant.
-        3. ``already_rotated`` → reuse-detection: revoke entire family +
-           invalid_grant. (Defense-in-depth; load_refresh_token now also
-           triggers this revoke when it sees a rotated_out record, so in
-           the mcp-sdk-driven path this branch is rarely reached.)
-        4. ``active`` → cascade Taiga refresh; on success issue new tokens in
-           the same family. Cascade failure does NOT revoke the family — the
-           still-valid access token continues to work until natural expiry.
+        1. Peek lookup — no state change. None → invalid_grant.
+        2. Pre-validate (client_id match, scope subset, defensive
+           rotated_out guard for direct callers that bypass
+           ``load_refresh_token``).
+        3. Cascade Taiga refresh. Failure raises invalid_grant; the MCP
+           refresh token is NOT rotated and the client can retry.
+        4. Atomic ``consume_refresh_token``. Race-window protection: any
+           ``already_rotated`` result here is a concurrent winner — revoke
+           the family per OAuth 2.1 reuse-detection semantics.
+        5. Atomic ``issue_new_generation`` — guards against a revoke that
+           may have happened between consume and issue (concurrent
+           load/exchange replay racing this branch).
         """
-        result = await self._store.consume_refresh_token(refresh_token.token)
-
-        if result.status == "not_found":
+        # Step 1: peek lookup (no state change)
+        record = await self._store.lookup_refresh_token(refresh_token.token)
+        if record is None:
             raise TokenError("invalid_grant", "Refresh token unknown")
-        if result.status == "expired":
-            raise TokenError("invalid_grant", "Refresh token expired")
 
-        if result.status == "already_rotated":
-            # Defense-in-depth — mcp-sdk's TokenHandler reaches this method only
-            # if load_refresh_token returned non-None; rotated_out records are
-            # filtered there. This branch covers code paths that bypass load (a
-            # direct caller) or a race where load and consume interleave on a
-            # fresh rotation.
-            revoked = await self._store.revoke_token_family(result.record.family_id)
+        # Defense-in-depth: ``load_refresh_token`` normally filters
+        # rotated_out (and revokes the family there). This branch handles
+        # direct callers that bypass load, plus the load/consume race
+        # window where two callers reach exchange before the first
+        # finishes consuming.
+        if record.rotated_out:
+            revoked = await self._store.revoke_token_family(record.family_id)
             _log.warning(
-                "Refresh-token reuse detected (via consume) for family=%s; "
-                "revoked %d tokens",
-                result.record.family_id, revoked,
+                "Refresh-token reuse detected (via exchange peek) for "
+                "family=%s; revoked %d tokens",
+                record.family_id, revoked,
             )
             raise TokenError("invalid_grant", "Refresh token already used")
-
-        # status == "active"; record is now rotated_out
-        record = result.record
 
         if record.client_id != client.client_id:
             raise TokenError(
@@ -515,24 +518,46 @@ class TaigaOAuthProvider(OAuthProvider):
                 "Requested scopes exceed original grant",
             )
 
+        # Step 2: cascade BEFORE consuming. On cascade failure, the MCP
+        # refresh token stays active and the client can retry.
         try:
             taiga = await self._taiga.refresh_taiga_token(record.taiga_refresh_token)
         except TaigaRefreshError as exc:
             _log.info(
-                "Taiga refresh failed for family=%s; family preserved "
-                "(rotated_out tombstone remains): %s",
+                "Taiga refresh failed for family=%s; refresh token not "
+                "rotated, client can retry the same refresh token: %s",
                 record.family_id, exc,
             )
             raise TokenError("invalid_grant", "Upstream auth refresh failed")
 
+        # Step 3: atomic consume (only now flip rotated_out)
+        result = await self._store.consume_refresh_token(refresh_token.token)
+        if result.status == "not_found":
+            # Vanished between peek and consume — likely revoked by a
+            # concurrent reuse-detection. Treat as already-used.
+            raise TokenError("invalid_grant", "Refresh token unknown")
+        if result.status == "expired":
+            raise TokenError("invalid_grant", "Refresh token expired")
+        if result.status == "already_rotated":
+            # Race: another concurrent request consumed first. Revoke
+            # the family per OAuth 2.1 reuse-detection semantics.
+            revoked = await self._store.revoke_token_family(result.record.family_id)
+            _log.warning(
+                "Refresh-token reuse detected (via consume) for family=%s; "
+                "revoked %d tokens",
+                result.record.family_id, revoked,
+            )
+            raise TokenError("invalid_grant", "Refresh token already used")
+
+        # status == "active"; record is now rotated_out. Use the freshly
+        # returned record for symmetry (same data as the earlier peek).
+        record = result.record
+
+        # Step 4: atomic issue. Race-protected against a revoke that
+        # may have happened between our consume and now.
         now = datetime.now(timezone.utc)
         new_access = secrets.token_urlsafe(32)
         new_refresh = secrets.token_urlsafe(32)
-
-        # Atomic issue: refuses to write back if the family was revoked while
-        # this coroutine was suspended inside ``refresh_taiga_token``. Without
-        # this guard, a concurrent reuse-detection revoke can be silently
-        # undone by the resumed cascade (T0-T6 race in the v2.5.0 review).
         issued = await self._store.issue_new_generation(
             family_id=record.family_id,
             access_token=new_access,
@@ -549,7 +574,7 @@ class TaigaOAuthProvider(OAuthProvider):
         )
         if not issued:
             _log.warning(
-                "Family was revoked during Taiga cascade for family=%s; "
+                "Family was revoked during exchange for family=%s; "
                 "refusing to issue new generation",
                 record.family_id,
             )

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -52,6 +52,7 @@ from langchain_taiga.auth.taiga_client import (
     TaigaAuthenticationError,
     TaigaClient,
     TaigaRefreshError,
+    TaigaRefreshTokenInvalidError,
 )
 
 ACCESS_TOKEN_TTL = timedelta(hours=1)
@@ -518,14 +519,35 @@ class TaigaOAuthProvider(OAuthProvider):
                 "Requested scopes exceed original grant",
             )
 
-        # Step 2: cascade BEFORE consuming. On cascade failure, the MCP
-        # refresh token stays active and the client can retry.
+        # Step 2: cascade BEFORE consuming. On a TRANSIENT cascade failure
+        # (5xx, network blip, malformed-200, 429 rate-limit) the MCP refresh
+        # token stays active and the client can retry. On a Taiga 4xx
+        # "this refresh token is invalid" (TaigaRefreshTokenInvalidError),
+        # the most likely cause is that another concurrent request already
+        # rotated the same upstream refresh — that's a replay signal, so
+        # we revoke the family per OAuth 2.1 reuse-detection.
         try:
             taiga = await self._taiga.refresh_taiga_token(record.taiga_refresh_token)
+        except TaigaRefreshTokenInvalidError as exc:
+            # Subclass check MUST come before the broader TaigaRefreshError
+            # except clause below. Taiga rejecting the refresh token (4xx)
+            # is a strong signal that a concurrent request already rotated
+            # it server-side — without this branch, the concurrent loser
+            # would silently fall through to the transient-preserve path,
+            # the original (still-active) MCP refresh would survive, and
+            # the replay attempt would go undetected.
+            revoked = await self._store.revoke_token_family(record.family_id)
+            _log.warning(
+                "Taiga rejected refresh token (likely concurrent replay) "
+                "for family=%s; revoked %d tokens: %s",
+                record.family_id, revoked, exc,
+            )
+            raise TokenError("invalid_grant", "Refresh token already used")
         except TaigaRefreshError as exc:
             _log.info(
-                "Taiga refresh failed for family=%s; refresh token not "
-                "rotated, client can retry the same refresh token: %s",
+                "Taiga refresh failed (transient) for family=%s; refresh "
+                "token not rotated, client can retry the same refresh "
+                "token: %s",
                 record.family_id, exc,
             )
             raise TokenError("invalid_grant", "Upstream auth refresh failed")

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -48,7 +48,11 @@ from mcp.shared.auth import (
 )
 
 from langchain_taiga.auth.store import InMemoryStore
-from langchain_taiga.auth.taiga_client import TaigaAuthenticationError, TaigaClient
+from langchain_taiga.auth.taiga_client import (
+    TaigaAuthenticationError,
+    TaigaClient,
+    TaigaRefreshError,
+)
 
 ACCESS_TOKEN_TTL = timedelta(hours=1)
 AUTH_CODE_TTL = timedelta(minutes=10)
@@ -419,7 +423,7 @@ class TaigaOAuthProvider(OAuthProvider):
             scope=" ".join(consumed.scopes),
         )
 
-    # ---- Refresh tokens (deferred to v2) --------------------------------
+    # ---- Refresh tokens (rotation + reuse-detection) --------------------
 
     async def load_refresh_token(
         self, client: OAuthClientInformationFull, refresh_token: str
@@ -447,7 +451,92 @@ class TaigaOAuthProvider(OAuthProvider):
         refresh_token: RefreshToken,
         scopes: List[str],
     ) -> OAuthToken:
-        raise NotImplementedError("Refresh tokens deferred to v2")
+        """Exchange a refresh token for a new access+refresh pair.
+
+        Flow:
+        1. Atomic consume_refresh_token routes to one of four branches.
+        2. ``not_found`` / ``expired`` → invalid_grant.
+        3. ``already_rotated`` → reuse-detection: revoke entire family +
+           invalid_grant. This is the ONLY proactive-revoke code path.
+        4. ``active`` → cascade Taiga refresh; on success issue new tokens in
+           the same family. Cascade failure does NOT revoke the family — the
+           still-valid access token continues to work until natural expiry.
+        """
+        result = await self._store.consume_refresh_token(refresh_token.token)
+
+        if result.status == "not_found":
+            raise TokenError("invalid_grant", "Refresh token unknown")
+        if result.status == "expired":
+            raise TokenError("invalid_grant", "Refresh token expired")
+
+        if result.status == "already_rotated":
+            revoked = await self._store.revoke_token_family(result.record.family_id)
+            _log.warning(
+                "Refresh-token reuse detected for family=%s; revoked %d tokens",
+                result.record.family_id, revoked,
+            )
+            raise TokenError("invalid_grant", "Refresh token already used")
+
+        # status == "active"; record is now rotated_out
+        record = result.record
+
+        if record.client_id != client.client_id:
+            raise TokenError(
+                "invalid_client",
+                "Refresh token issued to different client",
+            )
+
+        requested_scopes = list(scopes) if scopes else list(record.scopes)
+        if not set(requested_scopes).issubset(set(record.scopes)):
+            raise TokenError(
+                "invalid_scope",
+                "Requested scopes exceed original grant",
+            )
+
+        try:
+            taiga = await self._taiga.refresh_taiga_token(record.taiga_refresh_token)
+        except TaigaRefreshError as exc:
+            _log.info(
+                "Taiga refresh failed for family=%s; family preserved "
+                "(rotated_out tombstone remains): %s",
+                record.family_id, exc,
+            )
+            raise TokenError("invalid_grant", f"Upstream auth refresh failed: {exc}")
+
+        now = datetime.now(timezone.utc)
+        new_access = secrets.token_urlsafe(32)
+        new_refresh = secrets.token_urlsafe(32)
+
+        await self._store.store_access_token(
+            token=new_access,
+            family_id=record.family_id,
+            taiga_auth_token=taiga.auth_token,
+            taiga_refresh_token=taiga.refresh,
+            taiga_user_id=record.taiga_user_id,
+            taiga_username=record.taiga_username,
+            client_id=record.client_id,
+            scopes=requested_scopes,
+            expires_at=now + ACCESS_TOKEN_TTL,
+        )
+        await self._store.store_refresh_token(
+            token=new_refresh,
+            family_id=record.family_id,
+            client_id=record.client_id,
+            taiga_auth_token=taiga.auth_token,
+            taiga_refresh_token=taiga.refresh,
+            taiga_user_id=record.taiga_user_id,
+            taiga_username=record.taiga_username,
+            scopes=record.scopes,
+            expires_at=now + REFRESH_TOKEN_TTL,
+        )
+
+        return OAuthToken(
+            access_token=new_access,
+            refresh_token=new_refresh,
+            token_type="Bearer",
+            expires_in=int(ACCESS_TOKEN_TTL.total_seconds()),
+            scope=" ".join(requested_scopes),
+        )
 
     # ---- Access token verification --------------------------------------
 

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -10,16 +10,6 @@ auto-mounting of:
 
 The custom HTML login page is NOT auto-mounted — it is registered in
 remote_server.py via ``mcp.custom_route("/oauth/login", ...)``.
-
-Phase 0 deltas applied (verified against fastmcp 2.14.5 + mcp SDK):
-- ``AccessToken`` is imported from ``fastmcp.server.auth`` (it has the
-  ``claims`` field; the mcp.server.auth.provider one does not).
-- ``ClientRegistrationOptions`` lives in ``mcp.server.auth.settings``
-  (not ``fastmcp.server.auth``).
-- ``OAuthProvider.__init__`` requires both ``base_url`` and ``issuer_url``.
-- ``AuthorizationCode`` requires ``redirect_uri_provided_explicitly: bool``.
-- ``AuthorizationParams`` required fields: ``state``, ``scopes``,
-  ``code_challenge``, ``redirect_uri``, ``redirect_uri_provided_explicitly``.
 """
 
 from __future__ import annotations
@@ -355,8 +345,8 @@ class TaigaOAuthProvider(OAuthProvider):
             code_challenge=record.code_challenge,
             scopes=list(record.scopes),
             expires_at=record.expires_at.timestamp(),
-            # Phase 0 delta: required field. We received the redirect_uri
-            # explicitly from the original /authorize request, not derived.
+            # Required by AuthorizationCode constructor; the redirect_uri
+            # came from the original /authorize request.
             redirect_uri_provided_explicitly=True,
         )
 
@@ -426,6 +416,24 @@ class TaigaOAuthProvider(OAuthProvider):
 
     # ---- Refresh tokens (rotation + reuse-detection) --------------------
 
+    async def _revoke_family_for_replay(
+        self, *, family_id: str, detection_site: str
+    ) -> int:
+        """Centralize the reuse-detection response: revoke the family + audit log.
+
+        All four detection sites (load_refresh_token's rotated_out branch,
+        exchange_refresh_token's defensive peek + Taiga 4xx + consume's
+        already_rotated) funnel through here so the WARNING message format
+        is uniform — ``grep "reuse detected" production.log`` returns all four
+        cases with the same structure.
+        """
+        revoked = await self._store.revoke_token_family(family_id)
+        _log.warning(
+            "Refresh-token reuse detected (%s) for family=%s; revoked %d tokens",
+            detection_site, family_id, revoked,
+        )
+        return revoked
+
     async def load_refresh_token(
         self, client: OAuthClientInformationFull, refresh_token: str
     ) -> Optional[RefreshToken]:
@@ -446,11 +454,8 @@ class TaigaOAuthProvider(OAuthProvider):
             # means revoke" — the same branch in exchange_refresh_token is
             # defensive-only (mcp-sdk doesn't reach it after we return None
             # here, but anyone calling exchange_refresh_token directly would).
-            revoked = await self._store.revoke_token_family(record.family_id)
-            _log.warning(
-                "Refresh-token reuse detected (via load) for family=%s; "
-                "revoked %d tokens",
-                record.family_id, revoked,
+            await self._revoke_family_for_replay(
+                family_id=record.family_id, detection_site="load"
             )
             return None
         return RefreshToken(
@@ -468,10 +473,10 @@ class TaigaOAuthProvider(OAuthProvider):
     ) -> OAuthToken:
         """Exchange a refresh token for a new access+refresh pair.
 
-        Cascade-first ordering (Codex P2 fix): validate + cascade BEFORE
-        consuming the MCP refresh token. A transient Taiga failure
-        (5xx, ReadTimeout, malformed-200) therefore leaves the refresh
-        token usable for retry rather than forcing a full re-OAuth.
+        Cascade-first ordering: validate + cascade BEFORE consuming the MCP
+        refresh token. A transient Taiga failure (5xx, ReadTimeout,
+        malformed-200) therefore leaves the refresh token usable for retry
+        rather than forcing a full re-OAuth.
 
         Flow:
         1. Peek lookup — no state change. None → invalid_grant.
@@ -498,11 +503,8 @@ class TaigaOAuthProvider(OAuthProvider):
         # window where two callers reach exchange before the first
         # finishes consuming.
         if record.rotated_out:
-            revoked = await self._store.revoke_token_family(record.family_id)
-            _log.warning(
-                "Refresh-token reuse detected (via exchange peek) for "
-                "family=%s; revoked %d tokens",
-                record.family_id, revoked,
+            await self._revoke_family_for_replay(
+                family_id=record.family_id, detection_site="exchange peek"
             )
             raise TokenError("invalid_grant", "Refresh token already used")
 
@@ -536,12 +538,10 @@ class TaigaOAuthProvider(OAuthProvider):
             # would silently fall through to the transient-preserve path,
             # the original (still-active) MCP refresh would survive, and
             # the replay attempt would go undetected.
-            revoked = await self._store.revoke_token_family(record.family_id)
-            _log.warning(
-                "Taiga rejected refresh token (likely concurrent replay) "
-                "for family=%s; revoked %d tokens: %s",
-                record.family_id, revoked, exc,
+            await self._revoke_family_for_replay(
+                family_id=record.family_id, detection_site="taiga 4xx"
             )
+            _log.info("Taiga refresh-token rejection detail: %s", exc)
             raise TokenError("invalid_grant", "Refresh token already used")
         except TaigaRefreshError as exc:
             _log.info(
@@ -564,11 +564,8 @@ class TaigaOAuthProvider(OAuthProvider):
             # Race: another concurrent request consumed first. Revoke
             # the family per OAuth 2.1 reuse-detection semantics.
             assert result.record is not None  # narrowing for mypy; status invariant guarantees this
-            revoked = await self._store.revoke_token_family(result.record.family_id)
-            _log.warning(
-                "Refresh-token reuse detected (via consume) for family=%s; "
-                "revoked %d tokens",
-                result.record.family_id, revoked,
+            await self._revoke_family_for_replay(
+                family_id=result.record.family_id, detection_site="consume"
             )
             raise TokenError("invalid_grant", "Refresh token already used")
 
@@ -633,8 +630,8 @@ class TaigaOAuthProvider(OAuthProvider):
             token=token,
             client_id=record.client_id,
             scopes=record.scopes,
-            # Phase 0 delta: fastmcp AccessToken expires_at is int|None
-            # (timestamp seconds), not datetime.
+            # fastmcp AccessToken expires_at is int|None (timestamp seconds),
+            # not datetime.
             expires_at=int(record.expires_at.timestamp()),
             claims={
                 "taiga_jwt": record.taiga_auth_token,

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -52,6 +52,7 @@ from langchain_taiga.auth.taiga_client import TaigaAuthenticationError, TaigaCli
 
 ACCESS_TOKEN_TTL = timedelta(hours=1)
 AUTH_CODE_TTL = timedelta(minutes=10)
+REFRESH_TOKEN_TTL = timedelta(days=30)
 
 _log = logging.getLogger(__name__)
 
@@ -383,19 +384,36 @@ class TaigaOAuthProvider(OAuthProvider):
                 "redirect_uri mismatch with the original authorization request",
             )
 
+        now = datetime.now(timezone.utc)
+        family_id = secrets.token_urlsafe(16)
         mcp_access_token = secrets.token_urlsafe(32)
+        mcp_refresh_token = secrets.token_urlsafe(32)
+
         await self._store.store_access_token(
             token=mcp_access_token,
+            family_id=family_id,
             taiga_auth_token=consumed.taiga_auth_token,
             taiga_refresh_token=consumed.taiga_refresh_token,
             taiga_user_id=consumed.taiga_user_id,
             taiga_username=consumed.taiga_username,
-            expires_at=datetime.now(timezone.utc) + ACCESS_TOKEN_TTL,
+            expires_at=now + ACCESS_TOKEN_TTL,
             client_id=consumed.client_id,
             scopes=consumed.scopes,
         )
+        await self._store.store_refresh_token(
+            token=mcp_refresh_token,
+            family_id=family_id,
+            client_id=consumed.client_id,
+            taiga_auth_token=consumed.taiga_auth_token,
+            taiga_refresh_token=consumed.taiga_refresh_token,
+            taiga_user_id=consumed.taiga_user_id,
+            taiga_username=consumed.taiga_username,
+            scopes=consumed.scopes,
+            expires_at=now + REFRESH_TOKEN_TTL,
+        )
         return OAuthToken(
             access_token=mcp_access_token,
+            refresh_token=mcp_refresh_token,
             token_type="Bearer",
             expires_in=int(ACCESS_TOKEN_TTL.total_seconds()),
             scope=" ".join(consumed.scopes),

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -507,28 +507,31 @@ class TaigaOAuthProvider(OAuthProvider):
         new_access = secrets.token_urlsafe(32)
         new_refresh = secrets.token_urlsafe(32)
 
-        await self._store.store_access_token(
-            token=new_access,
+        # Atomic issue: refuses to write back if the family was revoked while
+        # this coroutine was suspended inside ``refresh_taiga_token``. Without
+        # this guard, a concurrent reuse-detection revoke can be silently
+        # undone by the resumed cascade (T0-T6 race in the v2.5.0 review).
+        issued = await self._store.issue_new_generation(
             family_id=record.family_id,
+            access_token=new_access,
+            refresh_token=new_refresh,
             taiga_auth_token=taiga.auth_token,
             taiga_refresh_token=taiga.refresh,
             taiga_user_id=record.taiga_user_id,
             taiga_username=record.taiga_username,
             client_id=record.client_id,
-            scopes=requested_scopes,
-            expires_at=now + ACCESS_TOKEN_TTL,
+            access_scopes=requested_scopes,
+            refresh_scopes=record.scopes,
+            access_expires_at=now + ACCESS_TOKEN_TTL,
+            refresh_expires_at=now + REFRESH_TOKEN_TTL,
         )
-        await self._store.store_refresh_token(
-            token=new_refresh,
-            family_id=record.family_id,
-            client_id=record.client_id,
-            taiga_auth_token=taiga.auth_token,
-            taiga_refresh_token=taiga.refresh,
-            taiga_user_id=record.taiga_user_id,
-            taiga_username=record.taiga_username,
-            scopes=record.scopes,
-            expires_at=now + REFRESH_TOKEN_TTL,
-        )
+        if not issued:
+            _log.warning(
+                "Family was revoked during Taiga cascade for family=%s; "
+                "refusing to issue new generation",
+                record.family_id,
+            )
+            raise TokenError("invalid_grant", "Refresh token already used")
 
         return OAuthToken(
             access_token=new_access,

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -563,6 +563,7 @@ class TaigaOAuthProvider(OAuthProvider):
         if result.status == "already_rotated":
             # Race: another concurrent request consumed first. Revoke
             # the family per OAuth 2.1 reuse-detection semantics.
+            assert result.record is not None  # narrowing for mypy; status invariant guarantees this
             revoked = await self._store.revoke_token_family(result.record.family_id)
             _log.warning(
                 "Refresh-token reuse detected (via consume) for family=%s; "
@@ -573,6 +574,7 @@ class TaigaOAuthProvider(OAuthProvider):
 
         # status == "active"; record is now rotated_out. Use the freshly
         # returned record for symmetry (same data as the earlier peek).
+        assert result.record is not None  # narrowing for mypy; status invariant guarantees this
         record = result.record
 
         # Step 4: atomic issue. Race-protected against a revoke that

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -501,7 +501,7 @@ class TaigaOAuthProvider(OAuthProvider):
                 "(rotated_out tombstone remains): %s",
                 record.family_id, exc,
             )
-            raise TokenError("invalid_grant", f"Upstream auth refresh failed: {exc}")
+            raise TokenError("invalid_grant", "Upstream auth refresh failed")
 
         now = datetime.now(timezone.utc)
         new_access = secrets.token_urlsafe(32)

--- a/langchain_taiga/auth/provider.py
+++ b/langchain_taiga/auth/provider.py
@@ -430,13 +430,27 @@ class TaigaOAuthProvider(OAuthProvider):
     ) -> Optional[RefreshToken]:
         """Lookup a refresh token by string and return the RefreshToken model.
 
-        Returns rotated_out records too — the FastMCP layer routes them through
-        to exchange_refresh_token where reuse-detection fires. Cross-client
-        presentations short-circuit to None here (mcp-sdk also enforces this
-        before reaching exchange_refresh_token in production).
+        Reuse-detection happens HERE rather than only in exchange_refresh_token:
+        if we return the record to mcp-sdk's TokenHandler and the SDK then
+        rejects the request on a pre-check (e.g. invalid_scope), we never get
+        a chance to revoke the family. By revoking-and-returning-None on a
+        rotated_out record up front, the SDK sees invalid_grant and the
+        attacker can't bypass the security check by submitting bad scopes.
         """
         record = await self._store.lookup_refresh_token(refresh_token)
         if record is None or record.client_id != client.client_id:
+            return None
+        if record.rotated_out:
+            # Reuse-detection. Single source of truth for "rotated_out replay
+            # means revoke" — the same branch in exchange_refresh_token is
+            # defensive-only (mcp-sdk doesn't reach it after we return None
+            # here, but anyone calling exchange_refresh_token directly would).
+            revoked = await self._store.revoke_token_family(record.family_id)
+            _log.warning(
+                "Refresh-token reuse detected (via load) for family=%s; "
+                "revoked %d tokens",
+                record.family_id, revoked,
+            )
             return None
         return RefreshToken(
             token=record.token,
@@ -457,7 +471,9 @@ class TaigaOAuthProvider(OAuthProvider):
         1. Atomic consume_refresh_token routes to one of four branches.
         2. ``not_found`` / ``expired`` → invalid_grant.
         3. ``already_rotated`` → reuse-detection: revoke entire family +
-           invalid_grant. This is the ONLY proactive-revoke code path.
+           invalid_grant. (Defense-in-depth; load_refresh_token now also
+           triggers this revoke when it sees a rotated_out record, so in
+           the mcp-sdk-driven path this branch is rarely reached.)
         4. ``active`` → cascade Taiga refresh; on success issue new tokens in
            the same family. Cascade failure does NOT revoke the family — the
            still-valid access token continues to work until natural expiry.
@@ -470,9 +486,15 @@ class TaigaOAuthProvider(OAuthProvider):
             raise TokenError("invalid_grant", "Refresh token expired")
 
         if result.status == "already_rotated":
+            # Defense-in-depth — mcp-sdk's TokenHandler reaches this method only
+            # if load_refresh_token returned non-None; rotated_out records are
+            # filtered there. This branch covers code paths that bypass load (a
+            # direct caller) or a race where load and consume interleave on a
+            # fresh rotation.
             revoked = await self._store.revoke_token_family(result.record.family_id)
             _log.warning(
-                "Refresh-token reuse detected for family=%s; revoked %d tokens",
+                "Refresh-token reuse detected (via consume) for family=%s; "
+                "revoked %d tokens",
                 result.record.family_id, revoked,
             )
             raise TokenError("invalid_grant", "Refresh token already used")

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import hmac
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 
 @dataclass
@@ -59,6 +59,22 @@ class RefreshTokenRecord:
     scopes: List[str]
     expires_at: datetime
     rotated_out: bool = False
+
+
+@dataclass
+class ConsumeRefreshResult:
+    """Discriminated result of the atomic consume_refresh_token operation.
+
+    - ``active`` — token was active; ``record.rotated_out`` has been flipped
+      to True in place; the caller now owns the right to mint a new family
+      generation.
+    - ``already_rotated`` — token was already consumed; the caller MUST
+      revoke the family (reuse-detection signal).
+    - ``expired`` — record exists but past its ``expires_at``.
+    - ``not_found`` — no record under this token.
+    """
+    status: Literal["active", "already_rotated", "expired", "not_found"]
+    record: Optional[RefreshTokenRecord]
 
 
 @dataclass
@@ -183,6 +199,47 @@ class InMemoryStore:
         if record.expires_at < datetime.now(timezone.utc):
             return None
         return record
+
+    async def consume_refresh_token(self, token: str) -> ConsumeRefreshResult:
+        """Atomic lookup + rotated_out transition.
+
+        Atomicity comes from asyncio's single-threaded execution: this method
+        contains no awaits between the read and the mutation, so concurrent
+        callers cannot interleave inside it. The first observer of a fresh
+        token sees status="active" and flips rotated_out; subsequent observers
+        see status="already_rotated".
+
+        For a future Redis / Postgres backend, this method must be implemented
+        as a Lua script or row-locked transaction to preserve the semantics.
+        """
+        record = self._refresh_tokens.get(token)
+        if record is None:
+            return ConsumeRefreshResult(status="not_found", record=None)
+        if record.expires_at < datetime.now(timezone.utc):
+            return ConsumeRefreshResult(status="expired", record=record)
+        if record.rotated_out:
+            return ConsumeRefreshResult(status="already_rotated", record=record)
+        record.rotated_out = True  # in-place mutation; atomic in asyncio
+        return ConsumeRefreshResult(status="active", record=record)
+
+    async def revoke_token_family(self, family_id: str) -> int:
+        """Delete every access and refresh token sharing this family_id.
+
+        Used by reuse-detection in TaigaOAuthProvider.exchange_refresh_token
+        when a rotated_out refresh token is presented. Returns the total
+        number of records purged.
+        """
+        purged_access = [
+            k for k, v in self._access_tokens.items() if v.family_id == family_id
+        ]
+        for k in purged_access:
+            self._access_tokens.pop(k, None)
+        purged_refresh = [
+            k for k, v in self._refresh_tokens.items() if v.family_id == family_id
+        ]
+        for k in purged_refresh:
+            self._refresh_tokens.pop(k, None)
+        return len(purged_access) + len(purged_refresh)
 
     # --- Auth codes -------------------------------------------------------
 

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -26,7 +26,7 @@ class AccessTokenRecord:
     client_id: str
     scopes: List[str]
     expires_at: datetime
-    family_id: str = ""  # NEW — links to refresh family; "" for legacy records
+    family_id: str = ""  # "" for pre-2.5.0 records
 
 
 @dataclass
@@ -233,8 +233,18 @@ class InMemoryStore:
             return ConsumeRefreshResult(status="expired", record=record)
         if record.rotated_out:
             return ConsumeRefreshResult(status="already_rotated", record=record)
-        record.rotated_out = True  # in-place mutation; atomic in asyncio
+        record.rotated_out = True
         return ConsumeRefreshResult(status="active", record=record)
+
+    def _sweep(self, mapping: dict, *, predicate) -> int:
+        """Bulk-delete dict entries matching predicate. Returns count purged.
+
+        Two-phase (collect keys, then pop) avoids dict-mutated-during-iteration.
+        """
+        stale = [k for k, v in mapping.items() if predicate(v)]
+        for k in stale:
+            mapping.pop(k, None)
+        return len(stale)
 
     async def revoke_token_family(self, family_id: str) -> int:
         """Delete every access and refresh token sharing this family_id.
@@ -256,17 +266,10 @@ class InMemoryStore:
         # cannot resurrect a family that was just revoked. The timestamp
         # lets ``cleanup_expired`` sweep stale tombstones.
         self._revoked_families[family_id] = datetime.now(timezone.utc)
-        purged_access = [
-            k for k, v in self._access_tokens.items() if v.family_id == family_id
-        ]
-        for k in purged_access:
-            self._access_tokens.pop(k, None)
-        purged_refresh = [
-            k for k, v in self._refresh_tokens.items() if v.family_id == family_id
-        ]
-        for k in purged_refresh:
-            self._refresh_tokens.pop(k, None)
-        return len(purged_access) + len(purged_refresh)
+        return (
+            self._sweep(self._access_tokens, predicate=lambda v: v.family_id == family_id)
+            + self._sweep(self._refresh_tokens, predicate=lambda v: v.family_id == family_id)
+        )
 
     async def issue_new_generation(
         self,
@@ -435,21 +438,6 @@ class InMemoryStore:
         Returns the total number of records purged.
         """
         now = datetime.now(timezone.utc)
-        purged_tokens = [
-            k for k, v in self._access_tokens.items() if v.expires_at < now
-        ]
-        for k in purged_tokens:
-            self._access_tokens.pop(k, None)
-        purged_codes = [
-            k for k, v in self._auth_codes.items() if v.expires_at < now
-        ]
-        for k in purged_codes:
-            self._auth_codes.pop(k, None)
-        purged_refresh = [
-            k for k, v in self._refresh_tokens.items() if v.expires_at < now
-        ]
-        for k in purged_refresh:
-            self._refresh_tokens.pop(k, None)
         # Tombstones for revoked families older than the max refresh-token
         # TTL serve no purpose — every refresh token in that family has
         # expired by now, so there is nothing left for reuse-detection to
@@ -457,17 +445,15 @@ class InMemoryStore:
         # ``provider.py``; we keep it inline here to avoid an import cycle
         # (provider imports store, not the other way around).
         tombstone_horizon = now - timedelta(days=30)
-        purged_tombstones = [
-            fid for fid, ts in self._revoked_families.items()
-            if ts < tombstone_horizon
-        ]
-        for fid in purged_tombstones:
-            self._revoked_families.pop(fid, None)
+        expired = lambda v: v.expires_at < now
         return (
-            len(purged_tokens)
-            + len(purged_codes)
-            + len(purged_refresh)
-            + len(purged_tombstones)
+            self._sweep(self._access_tokens, predicate=expired)
+            + self._sweep(self._auth_codes, predicate=expired)
+            + self._sweep(self._refresh_tokens, predicate=expired)
+            + self._sweep(
+                self._revoked_families,
+                predicate=lambda ts: ts < tombstone_horizon,
+            )
         )
 
     async def close(self) -> None:

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -26,6 +26,7 @@ class AccessTokenRecord:
     client_id: str
     scopes: List[str]
     expires_at: datetime
+    family_id: str = ""  # NEW — links to refresh family; "" for legacy records
 
 
 @dataclass
@@ -84,6 +85,7 @@ class InMemoryStore:
         client_id: str,
         scopes: List[str],
         expires_at: datetime,
+        family_id: str = "",
     ) -> None:
         self._access_tokens[token] = AccessTokenRecord(
             token=token,
@@ -94,6 +96,7 @@ class InMemoryStore:
             client_id=client_id,
             scopes=list(scopes),
             expires_at=expires_at,
+            family_id=family_id,
         )
 
     async def lookup_access_token(self, token: str) -> Optional[AccessTokenRecord]:

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -345,15 +345,29 @@ class InMemoryStore:
     # --- Cleanup ----------------------------------------------------------
 
     async def cleanup_expired(self) -> int:
-        """Sweep expired access tokens + auth codes. Returns total purged."""
+        """Sweep expired access tokens, auth codes, and refresh tokens.
+
+        Refresh-token sweep covers both active and rotated_out records — the
+        tombstones don't have a separate retention policy, just the same
+        REFRESH_TOKEN_TTL. Returns total records purged.
+        """
         now = datetime.now(timezone.utc)
-        purged_tokens = [k for k, v in self._access_tokens.items() if v.expires_at < now]
+        purged_tokens = [
+            k for k, v in self._access_tokens.items() if v.expires_at < now
+        ]
         for k in purged_tokens:
             self._access_tokens.pop(k, None)
-        purged_codes = [k for k, v in self._auth_codes.items() if v.expires_at < now]
+        purged_codes = [
+            k for k, v in self._auth_codes.items() if v.expires_at < now
+        ]
         for k in purged_codes:
             self._auth_codes.pop(k, None)
-        return len(purged_tokens) + len(purged_codes)
+        purged_refresh = [
+            k for k, v in self._refresh_tokens.items() if v.expires_at < now
+        ]
+        for k in purged_refresh:
+            self._refresh_tokens.pop(k, None)
+        return len(purged_tokens) + len(purged_codes) + len(purged_refresh)
 
     async def close(self) -> None:
         """No-op — kept for API symmetry with future persistent backends."""

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -100,6 +100,12 @@ class InMemoryStore:
         self._auth_codes: dict[str, AuthCodeRecord] = {}
         self._clients: dict[str, ClientRecord] = {}
         self._refresh_tokens: dict[str, RefreshTokenRecord] = {}
+        # Tombstone set for revoked families. Used by ``issue_new_generation``
+        # to refuse a write-back from a coroutine whose family was revoked
+        # while it was suspended inside the Taiga refresh cascade (otherwise
+        # a resumed exchange could resurrect a just-revoked family by storing
+        # new access + refresh tokens with the revoked ``family_id``).
+        self._revoked_families: set[str] = set()
 
     @classmethod
     async def from_env(cls) -> "InMemoryStore":
@@ -236,6 +242,11 @@ class InMemoryStore:
         # failure mode is silent mass-logout.
         if not family_id:
             return 0
+        # Flag the family BEFORE the pops. ``issue_new_generation`` checks
+        # this set with no intervening awaits between the check and its
+        # dict writes, so a coroutine suspended inside the Taiga cascade
+        # cannot resurrect a family that was just revoked.
+        self._revoked_families.add(family_id)
         purged_access = [
             k for k, v in self._access_tokens.items() if v.family_id == family_id
         ]
@@ -247,6 +258,60 @@ class InMemoryStore:
         for k in purged_refresh:
             self._refresh_tokens.pop(k, None)
         return len(purged_access) + len(purged_refresh)
+
+    async def issue_new_generation(
+        self,
+        *,
+        family_id: str,
+        access_token: str,
+        refresh_token: str,
+        taiga_auth_token: str,
+        taiga_refresh_token: str,
+        taiga_user_id: int,
+        taiga_username: str,
+        client_id: str,
+        access_scopes: List[str],
+        refresh_scopes: List[str],
+        access_expires_at: datetime,
+        refresh_expires_at: datetime,
+    ) -> bool:
+        """Atomically issue a new generation for a refresh family.
+
+        Returns True if the new access+refresh pair was persisted; False if
+        the family was revoked between consume and now (caller should raise
+        invalid_grant). The check + both dict writes happen inside this
+        method body with no intervening awaits, so asyncio's single-threaded
+        execution makes the operation atomic against concurrent revokes
+        that may have flipped _revoked_families.
+
+        Without this atomicity, a request suspended inside a cascade call can
+        resurrect a family that another coroutine just revoked.
+        """
+        if family_id in self._revoked_families:
+            return False
+        self._access_tokens[access_token] = AccessTokenRecord(
+            token=access_token,
+            taiga_auth_token=taiga_auth_token,
+            taiga_refresh_token=taiga_refresh_token,
+            taiga_user_id=taiga_user_id,
+            taiga_username=taiga_username,
+            client_id=client_id,
+            scopes=list(access_scopes),
+            expires_at=access_expires_at,
+            family_id=family_id,
+        )
+        self._refresh_tokens[refresh_token] = RefreshTokenRecord(
+            token=refresh_token,
+            family_id=family_id,
+            client_id=client_id,
+            taiga_auth_token=taiga_auth_token,
+            taiga_refresh_token=taiga_refresh_token,
+            taiga_user_id=taiga_user_id,
+            taiga_username=taiga_username,
+            scopes=list(refresh_scopes),
+            expires_at=refresh_expires_at,
+        )
+        return True
 
     # --- Auth codes -------------------------------------------------------
 

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -229,6 +229,13 @@ class InMemoryStore:
         when a rotated_out refresh token is presented. Returns the total
         number of records purged.
         """
+        # Defense: AccessTokenRecord.family_id defaults to "" for legacy
+        # (pre-2.5.0) records. A bare revoke_token_family("") would mass-purge
+        # every legacy record. Current call sites never pass "" (provider mints
+        # via secrets.token_urlsafe(16)), but the guard is one line and the
+        # failure mode is silent mass-logout.
+        if not family_id:
+            return 0
         purged_access = [
             k for k, v in self._access_tokens.items() if v.family_id == family_id
         ]

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -45,6 +45,23 @@ class AuthCodeRecord:
 
 
 @dataclass
+class RefreshTokenRecord:
+    """An MCP refresh token. Once exchanged, ``rotated_out`` is flipped to
+    True so a subsequent presentation triggers reuse-detection in
+    ``TaigaOAuthProvider.exchange_refresh_token``."""
+    token: str
+    family_id: str
+    client_id: str
+    taiga_auth_token: str
+    taiga_refresh_token: str
+    taiga_user_id: int
+    taiga_username: str
+    scopes: List[str]
+    expires_at: datetime
+    rotated_out: bool = False
+
+
+@dataclass
 class ClientRecord:
     client_id: str
     client_secret: Optional[str]
@@ -66,6 +83,7 @@ class InMemoryStore:
         self._access_tokens: dict[str, AccessTokenRecord] = {}
         self._auth_codes: dict[str, AuthCodeRecord] = {}
         self._clients: dict[str, ClientRecord] = {}
+        self._refresh_tokens: dict[str, RefreshTokenRecord] = {}
 
     @classmethod
     async def from_env(cls) -> "InMemoryStore":
@@ -122,6 +140,49 @@ class InMemoryStore:
         record.taiga_auth_token = taiga_auth_token
         record.taiga_refresh_token = taiga_refresh_token
         record.expires_at = expires_at
+
+    # --- Refresh tokens ---------------------------------------------------
+
+    async def store_refresh_token(
+        self,
+        *,
+        token: str,
+        family_id: str,
+        client_id: str,
+        taiga_auth_token: str,
+        taiga_refresh_token: str,
+        taiga_user_id: int,
+        taiga_username: str,
+        scopes: List[str],
+        expires_at: datetime,
+    ) -> None:
+        self._refresh_tokens[token] = RefreshTokenRecord(
+            token=token,
+            family_id=family_id,
+            client_id=client_id,
+            taiga_auth_token=taiga_auth_token,
+            taiga_refresh_token=taiga_refresh_token,
+            taiga_user_id=taiga_user_id,
+            taiga_username=taiga_username,
+            scopes=list(scopes),
+            expires_at=expires_at,
+        )
+
+    async def lookup_refresh_token(
+        self, token: str
+    ) -> Optional[RefreshTokenRecord]:
+        """Return the record only if it exists AND is not expired.
+
+        Returns rotated_out records so the FastMCP layer's
+        ``load_refresh_token`` can route them through to
+        ``exchange_refresh_token`` where reuse-detection fires.
+        """
+        record = self._refresh_tokens.get(token)
+        if record is None:
+            return None
+        if record.expires_at < datetime.now(timezone.utc):
+            return None
+        return record
 
     # --- Auth codes -------------------------------------------------------
 

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -48,7 +48,9 @@ class AuthCodeRecord:
 class RefreshTokenRecord:
     """An MCP refresh token. Once exchanged, ``rotated_out`` is flipped to
     True so a subsequent presentation triggers reuse-detection in
-    ``TaigaOAuthProvider.exchange_refresh_token``."""
+    ``TaigaOAuthProvider.load_refresh_token`` (which is the primary
+    detection point — ``exchange_refresh_token`` keeps a defensive branch
+    for direct callers that bypass load)."""
     token: str
     family_id: str
     client_id: str
@@ -199,9 +201,11 @@ class InMemoryStore:
     ) -> Optional[RefreshTokenRecord]:
         """Return the record only if it exists AND is not expired.
 
-        Returns rotated_out records so the FastMCP layer's
-        ``load_refresh_token`` can route them through to
-        ``exchange_refresh_token`` where reuse-detection fires.
+        Returns rotated_out records too — ``TaigaOAuthProvider.load_refresh_token``
+        inspects the ``rotated_out`` flag itself: if True, it revokes the
+        family on the spot and returns None to mcp-sdk's TokenHandler (which
+        then surfaces ``invalid_grant``). Filtering rotated_out here would
+        hide the replay signal from that detection path.
         """
         record = self._refresh_tokens.get(token)
         if record is None:

--- a/langchain_taiga/auth/store.py
+++ b/langchain_taiga/auth/store.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import hmac
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Literal, Optional
 
 
@@ -100,12 +100,16 @@ class InMemoryStore:
         self._auth_codes: dict[str, AuthCodeRecord] = {}
         self._clients: dict[str, ClientRecord] = {}
         self._refresh_tokens: dict[str, RefreshTokenRecord] = {}
-        # Tombstone set for revoked families. Used by ``issue_new_generation``
-        # to refuse a write-back from a coroutine whose family was revoked
-        # while it was suspended inside the Taiga refresh cascade (otherwise
-        # a resumed exchange could resurrect a just-revoked family by storing
-        # new access + refresh tokens with the revoked ``family_id``).
-        self._revoked_families: set[str] = set()
+        # Tombstone map for revoked families (family_id → revoked_at). Used
+        # by ``issue_new_generation`` to refuse a write-back from a coroutine
+        # whose family was revoked while it was suspended inside the Taiga
+        # refresh cascade (otherwise a resumed exchange could resurrect a
+        # just-revoked family by storing new access + refresh tokens with
+        # the revoked ``family_id``). Carrying a timestamp lets
+        # ``cleanup_expired`` sweep entries older than REFRESH_TOKEN_TTL —
+        # by then every refresh token in the family has expired, so the
+        # tombstone serves no further reuse-detection purpose.
+        self._revoked_families: dict[str, datetime] = {}
 
     @classmethod
     async def from_env(cls) -> "InMemoryStore":
@@ -243,10 +247,11 @@ class InMemoryStore:
         if not family_id:
             return 0
         # Flag the family BEFORE the pops. ``issue_new_generation`` checks
-        # this set with no intervening awaits between the check and its
+        # this map with no intervening awaits between the check and its
         # dict writes, so a coroutine suspended inside the Taiga cascade
-        # cannot resurrect a family that was just revoked.
-        self._revoked_families.add(family_id)
+        # cannot resurrect a family that was just revoked. The timestamp
+        # lets ``cleanup_expired`` sweep stale tombstones.
+        self._revoked_families[family_id] = datetime.now(timezone.utc)
         purged_access = [
             k for k, v in self._access_tokens.items() if v.family_id == family_id
         ]
@@ -410,11 +415,20 @@ class InMemoryStore:
     # --- Cleanup ----------------------------------------------------------
 
     async def cleanup_expired(self) -> int:
-        """Sweep expired access tokens, auth codes, and refresh tokens.
+        """Sweep expired access tokens, auth codes, refresh tokens, and
+        revoked-family tombstones.
 
         Refresh-token sweep covers both active and rotated_out records — the
-        tombstones don't have a separate retention policy, just the same
-        REFRESH_TOKEN_TTL. Returns total records purged.
+        rotated_out records don't have a separate retention policy, just the
+        same REFRESH_TOKEN_TTL.
+
+        Revoked-family tombstones older than REFRESH_TOKEN_TTL are also
+        swept — by that point every refresh token in the family has expired
+        (or been purged above), so the tombstone serves no further
+        reuse-detection purpose. Without this sweep ``_revoked_families``
+        would grow unboundedly across the pod's lifetime.
+
+        Returns the total number of records purged.
         """
         now = datetime.now(timezone.utc)
         purged_tokens = [
@@ -432,7 +446,25 @@ class InMemoryStore:
         ]
         for k in purged_refresh:
             self._refresh_tokens.pop(k, None)
-        return len(purged_tokens) + len(purged_codes) + len(purged_refresh)
+        # Tombstones for revoked families older than the max refresh-token
+        # TTL serve no purpose — every refresh token in that family has
+        # expired by now, so there is nothing left for reuse-detection to
+        # fire on. The 30-day horizon mirrors REFRESH_TOKEN_TTL in
+        # ``provider.py``; we keep it inline here to avoid an import cycle
+        # (provider imports store, not the other way around).
+        tombstone_horizon = now - timedelta(days=30)
+        purged_tombstones = [
+            fid for fid, ts in self._revoked_families.items()
+            if ts < tombstone_horizon
+        ]
+        for fid in purged_tombstones:
+            self._revoked_families.pop(fid, None)
+        return (
+            len(purged_tokens)
+            + len(purged_codes)
+            + len(purged_refresh)
+            + len(purged_tombstones)
+        )
 
     async def close(self) -> None:
         """No-op — kept for API symmetry with future persistent backends."""

--- a/langchain_taiga/auth/taiga_client.py
+++ b/langchain_taiga/auth/taiga_client.py
@@ -45,43 +45,26 @@ class TaigaClient:
     async def authenticate_user(
         self, username: str, password: str
     ) -> TaigaCredentials:
-        try:
-            async with httpx.AsyncClient(timeout=self._timeout) as http:
-                resp = await http.post(
-                    f"{self._api_url}/api/v1/auth",
-                    json={
-                        "type": "normal",
-                        "username": username,
-                        "password": password,
-                    },
-                )
-        except httpx.RequestError as exc:
-            # Transport failures (ReadTimeout, ConnectError, PoolTimeout, ...)
-            # surface as TaigaAuthenticationError so the login UI can retry
-            # without bubbling up as a generic 500.
-            raise TaigaAuthenticationError(
-                f"Taiga auth transport failed: {exc!r}"
-            ) from exc
+        async with httpx.AsyncClient(timeout=self._timeout) as http:
+            resp = await http.post(
+                f"{self._api_url}/api/v1/auth",
+                json={
+                    "type": "normal",
+                    "username": username,
+                    "password": password,
+                },
+            )
         if resp.status_code != 200:
             raise TaigaAuthenticationError(
                 f"Taiga auth failed: {resp.status_code} {resp.text[:200]}"
             )
-        # Wrap JSON-decoding + missing-field exceptions so a malformed 200
-        # response (rare but possible behind a misconfigured proxy) doesn't
-        # bubble as a generic 500 — the login UI can show a friendly retry
-        # instead.
-        try:
-            body = resp.json()
-            return TaigaCredentials(
-                auth_token=body["auth_token"],
-                refresh=body["refresh"],
-                user_id=int(body["id"]),
-                username=body["username"],
-            )
-        except (ValueError, KeyError, TypeError) as exc:
-            raise TaigaAuthenticationError(
-                f"Taiga auth response malformed: {exc!r}"
-            ) from exc
+        body = resp.json()
+        return TaigaCredentials(
+            auth_token=body["auth_token"],
+            refresh=body["refresh"],
+            user_id=int(body["id"]),
+            username=body["username"],
+        )
 
     async def refresh_taiga_token(self, refresh_token: str) -> RefreshedTokens:
         try:

--- a/langchain_taiga/auth/taiga_client.py
+++ b/langchain_taiga/auth/taiga_client.py
@@ -66,13 +66,22 @@ class TaigaClient:
             raise TaigaAuthenticationError(
                 f"Taiga auth failed: {resp.status_code} {resp.text[:200]}"
             )
-        body = resp.json()
-        return TaigaCredentials(
-            auth_token=body["auth_token"],
-            refresh=body["refresh"],
-            user_id=int(body["id"]),
-            username=body["username"],
-        )
+        # Wrap JSON-decoding + missing-field exceptions so a malformed 200
+        # response (rare but possible behind a misconfigured proxy) doesn't
+        # bubble as a generic 500 — the login UI can show a friendly retry
+        # instead.
+        try:
+            body = resp.json()
+            return TaigaCredentials(
+                auth_token=body["auth_token"],
+                refresh=body["refresh"],
+                user_id=int(body["id"]),
+                username=body["username"],
+            )
+        except (ValueError, KeyError, TypeError) as exc:
+            raise TaigaAuthenticationError(
+                f"Taiga auth response malformed: {exc!r}"
+            ) from exc
 
     async def refresh_taiga_token(self, refresh_token: str) -> RefreshedTokens:
         try:
@@ -96,5 +105,18 @@ class TaigaClient:
             raise TaigaRefreshError(
                 f"Taiga refresh failed: {resp.status_code} {resp.text[:200]}"
             )
-        body = resp.json()
-        return RefreshedTokens(auth_token=body["auth_token"], refresh=body["refresh"])
+        # Same rationale as refresh-transport failures above: a malformed 200
+        # (bad JSON or missing auth_token/refresh fields) MUST surface as
+        # TaigaRefreshError so the provider's cascade-failure branch catches
+        # it and keeps the family alive. Otherwise the response bubbles as a
+        # 500, the user retries with the now rotated_out refresh token, and
+        # reuse-detection mass-revokes the family on every Taiga blip.
+        try:
+            body = resp.json()
+            return RefreshedTokens(
+                auth_token=body["auth_token"], refresh=body["refresh"]
+            )
+        except (ValueError, KeyError, TypeError) as exc:
+            raise TaigaRefreshError(
+                f"Taiga refresh response malformed: {exc!r}"
+            ) from exc

--- a/langchain_taiga/auth/taiga_client.py
+++ b/langchain_taiga/auth/taiga_client.py
@@ -45,11 +45,23 @@ class TaigaClient:
     async def authenticate_user(
         self, username: str, password: str
     ) -> TaigaCredentials:
-        async with httpx.AsyncClient(timeout=self._timeout) as http:
-            resp = await http.post(
-                f"{self._api_url}/api/v1/auth",
-                json={"type": "normal", "username": username, "password": password},
-            )
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as http:
+                resp = await http.post(
+                    f"{self._api_url}/api/v1/auth",
+                    json={
+                        "type": "normal",
+                        "username": username,
+                        "password": password,
+                    },
+                )
+        except httpx.RequestError as exc:
+            # Transport failures (ReadTimeout, ConnectError, PoolTimeout, ...)
+            # surface as TaigaAuthenticationError so the login UI can retry
+            # without bubbling up as a generic 500.
+            raise TaigaAuthenticationError(
+                f"Taiga auth transport failed: {exc!r}"
+            ) from exc
         if resp.status_code != 200:
             raise TaigaAuthenticationError(
                 f"Taiga auth failed: {resp.status_code} {resp.text[:200]}"
@@ -63,11 +75,23 @@ class TaigaClient:
         )
 
     async def refresh_taiga_token(self, refresh_token: str) -> RefreshedTokens:
-        async with httpx.AsyncClient(timeout=self._timeout) as http:
-            resp = await http.post(
-                f"{self._api_url}/api/v1/auth/refresh",
-                json={"refresh": refresh_token},
-            )
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as http:
+                resp = await http.post(
+                    f"{self._api_url}/api/v1/auth/refresh",
+                    json={"refresh": refresh_token},
+                )
+        except httpx.RequestError as exc:
+            # Transient transport blips (ReadTimeout, ConnectError, ...) MUST
+            # surface as TaigaRefreshError so the provider's cascade-failure
+            # handler catches them and keeps the family alive. Letting these
+            # propagate would skip the except-TaigaRefreshError branch, the
+            # request would 500, and the user's retry — with the now
+            # rotated_out refresh token — would trigger reuse-detection and
+            # mass-revoke the family on every transient network blip.
+            raise TaigaRefreshError(
+                f"Taiga refresh transport failed: {exc!r}"
+            ) from exc
         if resp.status_code != 200:
             raise TaigaRefreshError(
                 f"Taiga refresh failed: {resp.status_code} {resp.text[:200]}"

--- a/langchain_taiga/auth/taiga_client.py
+++ b/langchain_taiga/auth/taiga_client.py
@@ -21,6 +21,15 @@ class TaigaRefreshError(Exception):
     """Refresh token rejected — claude.ai must restart OAuth."""
 
 
+class TaigaRefreshTokenInvalidError(TaigaRefreshError):
+    """Taiga rejected the refresh token (4xx, typically 401).
+
+    Distinguished from generic TaigaRefreshError because the provider
+    treats it as a concurrent-replay signal and revokes the token family,
+    rather than as a transient outage that should preserve the family.
+    """
+
+
 @dataclass
 class TaigaCredentials:
     auth_token: str
@@ -84,22 +93,41 @@ class TaigaClient:
             raise TaigaRefreshError(
                 f"Taiga refresh transport failed: {exc!r}"
             ) from exc
-        if resp.status_code != 200:
+        if resp.status_code == 200:
+            # Same rationale as refresh-transport failures above: a malformed
+            # 200 (bad JSON or missing auth_token/refresh fields) MUST surface
+            # as TaigaRefreshError so the provider's cascade-failure branch
+            # catches it and keeps the family alive. Otherwise the response
+            # bubbles as a 500, the user retries with the now rotated_out
+            # refresh token, and reuse-detection mass-revokes the family on
+            # every Taiga blip.
+            try:
+                body = resp.json()
+                return RefreshedTokens(
+                    auth_token=body["auth_token"], refresh=body["refresh"]
+                )
+            except (ValueError, KeyError, TypeError) as exc:
+                raise TaigaRefreshError(
+                    f"Taiga refresh response malformed: {exc!r}"
+                ) from exc
+        if resp.status_code == 429:
+            # Rate-limited — transient even though it's a 4xx. Surfaces as
+            # the generic TaigaRefreshError so the provider preserves the
+            # family and lets the client retry the same refresh token.
             raise TaigaRefreshError(
-                f"Taiga refresh failed: {resp.status_code} {resp.text[:200]}"
+                f"Taiga refresh rate-limited: {resp.status_code}"
             )
-        # Same rationale as refresh-transport failures above: a malformed 200
-        # (bad JSON or missing auth_token/refresh fields) MUST surface as
-        # TaigaRefreshError so the provider's cascade-failure branch catches
-        # it and keeps the family alive. Otherwise the response bubbles as a
-        # 500, the user retries with the now rotated_out refresh token, and
-        # reuse-detection mass-revokes the family on every Taiga blip.
-        try:
-            body = resp.json()
-            return RefreshedTokens(
-                auth_token=body["auth_token"], refresh=body["refresh"]
+        if 400 <= resp.status_code < 500:
+            # Other 4xx → Taiga is telling us the refresh token is invalid.
+            # Typical cause: the token was already rotated server-side by a
+            # concurrent request. Surface as the invalid-token subtype so
+            # the provider treats it as a concurrent-replay signal and
+            # revokes the family per OAuth 2.1 reuse-detection.
+            raise TaigaRefreshTokenInvalidError(
+                f"Taiga rejected refresh token: "
+                f"{resp.status_code} {resp.text[:200]}"
             )
-        except (ValueError, KeyError, TypeError) as exc:
-            raise TaigaRefreshError(
-                f"Taiga refresh response malformed: {exc!r}"
-            ) from exc
+        # 5xx — server-side outage, transient. Preserve the family.
+        raise TaigaRefreshError(
+            f"Taiga refresh failed: {resp.status_code} {resp.text[:200]}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.4.0"
-description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport."
+version = "2.5.0"
+description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5 adds OAuth refresh-token rotation with reuse-detection for stable long-lived connections."
 authors = []
 readme = "README.md"
 repository = "https://github.com/Shikenso-Analytics/langchain-taiga"

--- a/tests/unit_tests/test_cleanup_loop.py
+++ b/tests/unit_tests/test_cleanup_loop.py
@@ -168,3 +168,35 @@ async def test_cleanup_authorize_states_directly():
     assert purged == 1
     assert "expired" not in provider._authorize_states
     assert "fresh" in provider._authorize_states
+
+
+@pytest.mark.asyncio
+async def test_cleanup_loop_purges_expired_refresh_tokens():
+    """The store-level cleanup_expired (now sweeping refresh tokens) must
+    surface through run_cleanup_loop: an expired refresh record is removed
+    within one loop iteration."""
+    import asyncio
+    from langchain_taiga.auth.provider import run_cleanup_loop
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    await store.store_refresh_token(
+        token="stale_ref",
+        family_id="fam",
+        client_id="c",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        run_cleanup_loop(store, period_seconds=0.05, stop=stop)
+    )
+    await asyncio.sleep(0.1)
+    stop.set()
+    await task
+
+    assert "stale_ref" not in store._refresh_tokens

--- a/tests/unit_tests/test_cleanup_loop.py
+++ b/tests/unit_tests/test_cleanup_loop.py
@@ -199,4 +199,4 @@ async def test_cleanup_loop_purges_expired_refresh_tokens():
     stop.set()
     await task
 
-    assert "stale_ref" not in store._refresh_tokens
+    assert await store.lookup_refresh_token("stale_ref") is None

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -979,3 +979,123 @@ async def test_concurrent_exchange_same_refresh_token_one_wins_other_revokes_fam
     winner_oauth = successes[0]
     assert await fresh_store.lookup_access_token(winner_oauth.access_token) is None
     assert await fresh_store.lookup_refresh_token(winner_oauth.refresh_token) is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_cannot_escalate_scopes(fresh_store, respx_mock):
+    """A request for a scope superset of the original grant is rejected
+    with invalid_scope BEFORE any rotation happens — but consume already
+    flipped rotated_out, so the original refresh is effectively dead."""
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError) as excinfo:
+        await provider.exchange_refresh_token(
+            client=client_info,
+            refresh_token=refresh_obj,
+            scopes=["taiga", "admin"],
+        )
+    assert excinfo.value.error == "invalid_scope"
+
+
+@pytest.mark.asyncio
+async def test_refresh_with_subset_scopes_allowed(fresh_store, respx_mock):
+    """Requesting fewer scopes than the original grant succeeds; the new
+    access token carries only the requested subset."""
+    provider = _make_provider(fresh_store)
+    # Seed a multi-scope grant directly into the store (bypass auth flow for
+    # scope variety — the helper hardcodes ["taiga"]).
+    fam = "fam_subset"
+    expires_a = datetime.now(timezone.utc) + timedelta(hours=1)
+    expires_r = datetime.now(timezone.utc) + timedelta(days=30)
+    await fresh_store.store_access_token(
+        token="acc_seed",
+        family_id=fam,
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        client_id="cid_test_1",
+        scopes=["taiga", "read"],
+        expires_at=expires_a,
+    )
+    await fresh_store.store_refresh_token(
+        token="ref_seed",
+        family_id=fam,
+        client_id="cid_test_1",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga", "read"],
+        expires_at=expires_r,
+    )
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+
+    client_info = _make_client_info(
+        redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+        client_id="cid_test_1",
+        token_endpoint_auth_method="none",
+    )
+    refresh_obj = await provider.load_refresh_token(client_info, "ref_seed")
+    new_oauth = await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj, scopes=["read"]
+    )
+    assert "read" in new_oauth.scope
+    assert "taiga" not in new_oauth.scope
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_from_different_client_rejected(
+    fresh_store, respx_mock
+):
+    """Client A's refresh + Client B's identity → invalid_client.
+
+    Note: in production, mcp-sdk's load_refresh_token filters this earlier
+    (returns None for cross-client), but exchange_refresh_token has a
+    defensive check too. We exercise that defensive path by seeding the
+    record directly and bypassing the load step's client filter.
+    """
+    from mcp.server.auth.provider import RefreshToken, TokenError
+
+    await fresh_store.store_refresh_token(
+        token="ref_alice",
+        family_id="fam",
+        client_id="cid_alice",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="alice",
+        scopes=["taiga"],
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+
+    provider = _make_provider(fresh_store)
+    bob_info = _make_client_info(
+        redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+        client_id="cid_bob",
+        token_endpoint_auth_method="none",
+    )
+    # Construct a RefreshToken model directly to bypass load_refresh_token's
+    # cross-client filter and reach exchange_refresh_token's defensive check.
+    rt = RefreshToken(
+        token="ref_alice",
+        client_id="cid_alice",
+        scopes=["taiga"],
+        expires_at=int(
+            (datetime.now(timezone.utc) + timedelta(days=30)).timestamp()
+        ),
+    )
+    with pytest.raises(TokenError) as excinfo:
+        await provider.exchange_refresh_token(
+            client=bob_info, refresh_token=rt, scopes=[]
+        )
+    assert excinfo.value.error == "invalid_client"

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -656,3 +656,207 @@ async def test_load_refresh_token_returns_none_for_cross_client(fresh_store):
         token_endpoint_auth_method="none",
     )
     assert await provider.load_refresh_token(other, "ref_other") is None
+
+
+async def _do_full_auth_flow(provider, fresh_store, respx_mock):
+    """Walk a registered client through authorize → login → exchange to
+    arrive at (oauth_token, family_id). Helper used by refresh tests below."""
+    from mcp.server.auth.provider import AuthorizationParams
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth").mock(
+        return_value=Response(
+            200,
+            json={
+                "auth_token": "alice_jwt_v1",
+                "refresh": "alice_ref_v1",
+                "id": 42,
+                "username": "alice",
+            },
+        )
+    )
+    client_info = await provider.register_client(
+        _make_client_info(
+            redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+            client_name="Claude",
+            token_endpoint_auth_method="none",
+        )
+    )
+    verifier = "verifier_for_alice_with_enough_entropy_xx"
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    redirect = await provider.authorize(
+        client=client_info,
+        params=AuthorizationParams(
+            state="csrf",
+            scopes=["taiga"],
+            code_challenge=challenge,
+            redirect_uri="https://claude.ai/api/mcp/auth_callback",
+            redirect_uri_provided_explicitly=True,
+        ),
+    )
+    internal_state = redirect.split("internal_state=", 1)[1]
+    code, _ = await provider.complete_login(
+        internal_state=internal_state, username="alice", password="x"
+    )
+    auth_code_obj = await provider.load_authorization_code(client_info, code)
+    oauth_token = await provider.exchange_authorization_code(
+        client=client_info, authorization_code=auth_code_obj
+    )
+    return client_info, oauth_token
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_exchange_returns_new_tokens(
+    fresh_store, respx_mock
+):
+    """Refresh roundtrip: new access + new refresh, both different from the
+    originals, with refresh_token field populated in the response."""
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    # Mock the Taiga refresh endpoint for the cascade
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200,
+            json={"auth_token": "alice_jwt_v2", "refresh": "alice_ref_v2"},
+        )
+    )
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    new_oauth = await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj, scopes=[]
+    )
+    assert new_oauth.access_token
+    assert new_oauth.access_token != oauth.access_token
+    assert new_oauth.refresh_token
+    assert new_oauth.refresh_token != oauth.refresh_token
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_cascades_to_taiga_refresh(
+    fresh_store, respx_mock
+):
+    """The /api/v1/auth/refresh endpoint must be called with the stored
+    taiga_refresh_token, and the rotated Taiga JWT must land in the new
+    access-token record."""
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    refresh_route = respx_mock.post(
+        "https://taiga.example.test/api/v1/auth/refresh"
+    ).mock(
+        return_value=Response(
+            200,
+            json={"auth_token": "alice_jwt_v2", "refresh": "alice_ref_v2"},
+        )
+    )
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    new_oauth = await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj, scopes=[]
+    )
+
+    assert refresh_route.called
+    # Body must carry the originally-stored taiga refresh token
+    body = refresh_route.calls[0].request.read().decode()
+    assert "alice_ref_v1" in body
+
+    # The new MCP access-token record must hold the rotated Taiga JWT
+    new_access_record = await fresh_store.lookup_access_token(new_oauth.access_token)
+    assert new_access_record.taiga_auth_token == "alice_jwt_v2"
+    assert new_access_record.taiga_refresh_token == "alice_ref_v2"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_family_persists_across_multiple_refreshes(
+    fresh_store, respx_mock
+):
+    """3× consecutive refreshes; all generations share the same family_id."""
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200,
+            json={"auth_token": "jwt_v2", "refresh": "ref_v2"},
+        )
+    )
+
+    initial_access = await fresh_store.lookup_access_token(oauth.access_token)
+    expected_family = initial_access.family_id
+
+    current = oauth
+    for _ in range(3):
+        refresh_obj = await provider.load_refresh_token(client_info, current.refresh_token)
+        current = await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+        access_record = await fresh_store.lookup_access_token(current.access_token)
+        refresh_record = await fresh_store.lookup_refresh_token(current.refresh_token)
+        assert access_record.family_id == expected_family
+        assert refresh_record.family_id == expected_family
+
+
+@pytest.mark.asyncio
+async def test_old_refresh_token_invalid_after_rotation(
+    fresh_store, respx_mock
+):
+    """After exchange, the original refresh token must be rejected on
+    second presentation — though doing so triggers reuse-detection
+    (covered by a separate test); here we just assert the rejection."""
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj, scopes=[]
+    )
+    # Second presentation of the SAME refresh_token: reload + retry
+    refresh_obj_2 = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError) as excinfo:
+        await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj_2, scopes=[]
+        )
+    assert excinfo.value.error == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_taiga_refresh_failure_preserves_family_and_old_access_token(
+    fresh_store, respx_mock, caplog
+):
+    """Cascade failure must NOT revoke the family. Previously-issued access
+    token continues to resolve; only the just-rotated refresh is consumed."""
+    import logging
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(500, text="taiga down")
+    )
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with caplog.at_level(logging.INFO, logger="langchain_taiga.auth.provider"):
+        with pytest.raises(TokenError) as excinfo:
+            await provider.exchange_refresh_token(
+                client=client_info, refresh_token=refresh_obj, scopes=[]
+            )
+    assert excinfo.value.error == "invalid_grant"
+
+    # The original access_token must STILL be valid (family preserved)
+    assert await fresh_store.lookup_access_token(oauth.access_token) is not None
+    # Only INFO log, no WARNING (not a security event)
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warning_records == []

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -832,7 +832,11 @@ async def test_taiga_refresh_failure_preserves_family_and_old_access_token(
     fresh_store, respx_mock, caplog
 ):
     """Cascade failure must NOT revoke the family. Previously-issued access
-    token continues to resolve; only the just-rotated refresh is consumed."""
+    token continues to resolve. Under the cascade-first ordering (Codex P2),
+    the refresh token is also NOT rotated on cascade failure — the client
+    can retry the same refresh token. The "retry succeeds" leg is covered
+    by ``test_transient_cascade_failure_allows_retry_with_same_refresh_token``;
+    here we just assert the family + access-token survival contract."""
     import logging
     from mcp.server.auth.provider import TokenError
 
@@ -995,8 +999,9 @@ async def test_concurrent_exchange_same_refresh_token_one_wins_other_revokes_fam
 @pytest.mark.asyncio
 async def test_refresh_cannot_escalate_scopes(fresh_store, respx_mock):
     """A request for a scope superset of the original grant is rejected
-    with invalid_scope BEFORE any rotation happens — but consume already
-    flipped rotated_out, so the original refresh is effectively dead."""
+    with invalid_scope. Under the cascade-first ordering (Codex P2), the
+    scope check happens before consume, so the refresh token remains
+    active — the client may retry with a valid scope subset."""
     from mcp.server.auth.provider import TokenError
 
     provider = _make_provider(fresh_store)
@@ -1117,7 +1122,18 @@ async def test_concurrent_exchange_with_cascade_does_not_resurrect_revoked_famil
     fresh_store, respx_mock
 ):
     """Race protection: a refresh suspended in Taiga cascade must NOT
-    write back tokens after another coroutine revoked the family."""
+    write back tokens after another coroutine revoked the family.
+
+    Under the cascade-first ordering (Codex P2 fix) the cascade happens
+    BEFORE consume_refresh_token, so suspending at the cascade gate leaves
+    the refresh token active in the store. A concurrent replay therefore
+    cannot trigger load-path reuse-detection. We instead simulate the
+    "family revoked while a refresh is in flight" race directly via
+    ``revoke_token_family``. The slow task must abort cleanly — either
+    via the consume's not_found branch (token was purged by revoke) or
+    via ``issue_new_generation`` refusing to write into a revoked family.
+    Either way, ``invalid_grant`` and no resurrection.
+    """
     import asyncio
     from mcp.server.auth.provider import TokenError
 
@@ -1134,27 +1150,33 @@ async def test_concurrent_exchange_with_cascade_does_not_resurrect_revoked_famil
 
     provider._taiga.refresh_taiga_token = slow_taiga_refresh  # type: ignore
 
-    # Kick off the slow refresh; it will suspend at cascade_gate.wait()
+    # Kick off the slow refresh; it suspends at cascade_gate.wait() BEFORE
+    # the consume call, so the refresh token is still active in the store.
     refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
     slow_task = asyncio.create_task(
         provider.exchange_refresh_token(
             client=client_info, refresh_token=refresh_obj, scopes=[]
         )
     )
-    await asyncio.sleep(0)  # let slow_task start and reach the await
+    await asyncio.sleep(0)  # let slow_task suspend at the cascade gate
 
-    # Replay with the now-rotated_out token → triggers reuse-detection
-    # inside load_refresh_token itself (which returns None after revoking).
-    replay_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
-    assert replay_obj is None
-    # Family is now revoked. Release the slow task.
+    # Simulate a concurrent revoke of the entire family while the slow
+    # task is parked in the cascade. This is the security property we
+    # care about: in-flight refreshes must not resurrect a revoked family.
+    access_record = await fresh_store.lookup_access_token(oauth.access_token)
+    assert access_record is not None
+    await fresh_store.revoke_token_family(access_record.family_id)
+
+    # Release the slow task. After cascade returns it calls
+    # consume_refresh_token (the token has been purged → "not_found") or
+    # issue_new_generation (family is in _revoked_families → False).
+    # Either path raises invalid_grant.
     cascade_gate.set()
     with pytest.raises(TokenError) as excinfo:
         await slow_task
     assert excinfo.value.error == "invalid_grant"
 
-    # The family should be entirely empty (the original access token revoked,
-    # and no resurrection happened).
+    # The family stays revoked: original access token gone, no resurrection.
     assert await fresh_store.lookup_access_token(oauth.access_token) is None
 
 
@@ -1256,3 +1278,96 @@ async def test_taiga_refresh_malformed_200_does_not_revoke_family(
     assert excinfo.value.error == "invalid_grant"
     # Family preserved
     assert await fresh_store.lookup_access_token(oauth.access_token) is not None
+
+
+@pytest.mark.asyncio
+async def test_transient_cascade_failure_allows_retry_with_same_refresh_token(
+    fresh_store, respx_mock
+):
+    """A transient Taiga 5xx must NOT rotate the MCP refresh token, so the
+    client can retry with the same refresh token instead of being forced
+    through a full OAuth flow.
+
+    Codex P2 fix: cascade-first ordering moves ``consume_refresh_token``
+    after the Taiga cascade succeeds. Without this, the previous fix to
+    revoke families on rotated-out replay turned every transient Taiga
+    blip into a forced re-OAuth (because the second retry attempt would
+    look like a replay)."""
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    # First attempt: Taiga returns 500
+    fail_route = respx_mock.post(
+        "https://taiga.example.test/api/v1/auth/refresh"
+    ).mock(return_value=Response(500, text="temporarily unavailable"))
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError) as excinfo:
+        await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+    assert excinfo.value.error == "invalid_grant"
+
+    # Refresh token must still be active (NOT rotated_out)
+    stored = await fresh_store.lookup_refresh_token(oauth.refresh_token)
+    assert stored is not None
+    assert stored.rotated_out is False
+
+    # Second attempt: same refresh token, Taiga now returns 200
+    fail_route.mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+    refresh_obj_retry = await provider.load_refresh_token(
+        client_info, oauth.refresh_token
+    )
+    new_oauth = await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj_retry, scopes=[]
+    )
+    assert new_oauth.access_token
+    assert new_oauth.refresh_token
+
+
+@pytest.mark.asyncio
+async def test_malformed_taiga_response_allows_retry_with_same_refresh_token(
+    fresh_store, respx_mock
+):
+    """Same contract as transient-5xx, but for malformed-200 (missing
+    fields). The user retries the same refresh token once Taiga recovers,
+    no full re-OAuth required."""
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    fail_route = respx_mock.post(
+        "https://taiga.example.test/api/v1/auth/refresh"
+    ).mock(return_value=Response(200, json={"unexpected": "shape"}))
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError):
+        await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+
+    # Refresh token must still be active (NOT rotated_out)
+    stored = await fresh_store.lookup_refresh_token(oauth.refresh_token)
+    assert stored is not None
+    assert stored.rotated_out is False
+
+    # Recovery: retry succeeds
+    fail_route.mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+    refresh_obj_retry = await provider.load_refresh_token(
+        client_info, oauth.refresh_token
+    )
+    new_oauth = await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj_retry, scopes=[]
+    )
+    assert new_oauth.access_token

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -1099,3 +1099,78 @@ async def test_refresh_token_from_different_client_rejected(
             client=bob_info, refresh_token=rt, scopes=[]
         )
     assert excinfo.value.error == "invalid_client"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_exchange_with_cascade_does_not_resurrect_revoked_family(
+    fresh_store, respx_mock
+):
+    """Race protection: a refresh suspended in Taiga cascade must NOT
+    write back tokens after another coroutine revoked the family."""
+    import asyncio
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    # Use a gate to deterministically suspend the cascade
+    cascade_gate = asyncio.Event()
+
+    async def slow_taiga_refresh(taiga_refresh_token: str):
+        from langchain_taiga.auth.taiga_client import RefreshedTokens
+        await cascade_gate.wait()
+        return RefreshedTokens(auth_token="jwt_v2", refresh="ref_v2")
+
+    provider._taiga.refresh_taiga_token = slow_taiga_refresh  # type: ignore
+
+    # Kick off the slow refresh; it will suspend at cascade_gate.wait()
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    slow_task = asyncio.create_task(
+        provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+    )
+    await asyncio.sleep(0)  # let slow_task start and reach the await
+
+    # Replay with the now-rotated_out token → triggers reuse-detection → revoke
+    replay_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError):
+        await provider.exchange_refresh_token(
+            client=client_info, refresh_token=replay_obj, scopes=[]
+        )
+    # Family is now revoked. Release the slow task.
+    cascade_gate.set()
+    with pytest.raises(TokenError) as excinfo:
+        await slow_task
+    assert excinfo.value.error == "invalid_grant"
+
+    # The family should be entirely empty (the original access token revoked,
+    # and no resurrection happened).
+    assert await fresh_store.lookup_access_token(oauth.access_token) is None
+
+
+@pytest.mark.asyncio
+async def test_taiga_refresh_transport_error_does_not_revoke_family(
+    fresh_store, respx_mock
+):
+    """Transient network errors must be caught as TaigaRefreshError so the
+    family stays alive (only the user has to re-OAuth on next attempt)."""
+    import httpx
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    # Simulate a ReadTimeout on the refresh endpoint
+    respx_mock.post(
+        "https://taiga.example.test/api/v1/auth/refresh"
+    ).mock(side_effect=httpx.ReadTimeout("simulated read timeout"))
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError) as excinfo:
+        await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+    assert excinfo.value.error == "invalid_grant"
+    # Family must still be alive: original access token still resolves
+    assert await fresh_store.lookup_access_token(oauth.access_token) is not None

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -594,3 +594,65 @@ async def test_authorization_code_exchange_issues_refresh_token(
     assert refresh_record is not None
     assert access_record.family_id == refresh_record.family_id
     assert access_record.family_id != ""
+
+
+@pytest.mark.asyncio
+async def test_load_refresh_token_returns_token_record_for_known(fresh_store):
+    """load_refresh_token must return a RefreshToken model for a token
+    stored by the provider, no longer the v1 stub-None."""
+    # Seed a refresh token directly into the store
+    await fresh_store.store_refresh_token(
+        token="ref_seed",
+        family_id="fam",
+        client_id="cid_test_1",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+    provider = _make_provider(fresh_store)
+    client_info = _make_client_info(
+        redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+        client_id="cid_test_1",
+        token_endpoint_auth_method="none",
+    )
+    token = await provider.load_refresh_token(client_info, "ref_seed")
+    assert token is not None
+    assert token.token == "ref_seed"
+    assert "taiga" in token.scopes
+
+
+@pytest.mark.asyncio
+async def test_load_refresh_token_returns_none_for_unknown(fresh_store):
+    provider = _make_provider(fresh_store)
+    client_info = _make_client_info(
+        redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+        client_id="cid_test_1",
+        token_endpoint_auth_method="none",
+    )
+    assert await provider.load_refresh_token(client_info, "ghost") is None
+
+
+@pytest.mark.asyncio
+async def test_load_refresh_token_returns_none_for_cross_client(fresh_store):
+    """A refresh issued to client A must not be loadable by client B."""
+    await fresh_store.store_refresh_token(
+        token="ref_other",
+        family_id="fam",
+        client_id="cid_owner",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+    provider = _make_provider(fresh_store)
+    other = _make_client_info(
+        redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+        client_id="cid_intruder",
+        token_endpoint_auth_method="none",
+    )
+    assert await provider.load_refresh_token(other, "ref_other") is None

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -863,3 +863,119 @@ async def test_taiga_refresh_failure_preserves_family_and_old_access_token(
     # Only INFO log, no WARNING (not a security event)
     warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
     assert warning_records == []
+
+
+@pytest.mark.asyncio
+async def test_reusing_rotated_out_refresh_revokes_entire_family(
+    fresh_store, respx_mock, caplog
+):
+    """Replay of a rotated_out refresh token: family revoke covers ALL
+    access + refresh tokens that share the family_id, including the
+    just-issued new ones."""
+    import logging
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    rotated = await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj, scopes=[]
+    )
+    # All four tokens currently exist in the store
+    assert await fresh_store.lookup_access_token(oauth.access_token) is not None
+    assert await fresh_store.lookup_access_token(rotated.access_token) is not None
+    assert await fresh_store.lookup_refresh_token(rotated.refresh_token) is not None
+
+    # Replay: re-present the original (now rotated_out) refresh
+    refresh_replay = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with caplog.at_level(logging.WARNING, logger="langchain_taiga.auth.provider"):
+        with pytest.raises(TokenError) as excinfo:
+            await provider.exchange_refresh_token(
+                client=client_info, refresh_token=refresh_replay, scopes=[]
+            )
+    assert excinfo.value.error == "invalid_grant"
+
+    # ALL four tokens (across both generations of the family) are now gone
+    assert await fresh_store.lookup_access_token(oauth.access_token) is None
+    assert await fresh_store.lookup_access_token(rotated.access_token) is None
+    assert await fresh_store.lookup_refresh_token(oauth.refresh_token) is None
+    assert await fresh_store.lookup_refresh_token(rotated.refresh_token) is None
+
+
+@pytest.mark.asyncio
+async def test_reuse_detection_logs_security_warning(
+    fresh_store, respx_mock, caplog
+):
+    """The replay event must surface at WARNING level for audit logs."""
+    import logging
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+
+    first = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    await provider.exchange_refresh_token(
+        client=client_info, refresh_token=first, scopes=[]
+    )
+    second = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with caplog.at_level(logging.WARNING, logger="langchain_taiga.auth.provider"):
+        with pytest.raises(TokenError):
+            await provider.exchange_refresh_token(
+                client=client_info, refresh_token=second, scopes=[]
+            )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("reuse detected" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_exchange_same_refresh_token_one_wins_other_revokes_family(
+    fresh_store, respx_mock
+):
+    """asyncio.gather two exchange calls on the same refresh token.
+    Atomicity of consume_refresh_token: exactly one observes status=active,
+    the other observes status=already_rotated and revokes the family.
+    Net result: even the winner's tokens are revoked."""
+    import asyncio
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+
+    async def attempt():
+        refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+        return await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+
+    results = await asyncio.gather(attempt(), attempt(), return_exceptions=True)
+    # Exactly one success, exactly one TokenError
+    successes = [r for r in results if not isinstance(r, BaseException)]
+    failures = [r for r in results if isinstance(r, TokenError)]
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert failures[0].error == "invalid_grant"
+
+    # The winner's just-issued tokens are gone — family was revoked by the
+    # losing call's reuse-detection branch.
+    winner_oauth = successes[0]
+    assert await fresh_store.lookup_access_token(winner_oauth.access_token) is None
+    assert await fresh_store.lookup_refresh_token(winner_oauth.refresh_token) is None

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -805,10 +805,9 @@ async def test_old_refresh_token_invalid_after_rotation(
     fresh_store, respx_mock
 ):
     """After exchange, the original refresh token must be rejected on
-    second presentation — though doing so triggers reuse-detection
-    (covered by a separate test); here we just assert the rejection."""
-    from mcp.server.auth.provider import TokenError
-
+    second presentation. Reuse-detection (covered by a separate test) now
+    fires inside ``load_refresh_token`` itself, so the second load
+    short-circuits to None instead of returning a stale RefreshToken."""
     provider = _make_provider(fresh_store)
     client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
 
@@ -822,13 +821,10 @@ async def test_old_refresh_token_invalid_after_rotation(
     await provider.exchange_refresh_token(
         client=client_info, refresh_token=refresh_obj, scopes=[]
     )
-    # Second presentation of the SAME refresh_token: reload + retry
+    # Second presentation of the SAME refresh_token: load returns None,
+    # which is mcp-sdk's signal to surface invalid_grant to the OAuth client.
     refresh_obj_2 = await provider.load_refresh_token(client_info, oauth.refresh_token)
-    with pytest.raises(TokenError) as excinfo:
-        await provider.exchange_refresh_token(
-            client=client_info, refresh_token=refresh_obj_2, scopes=[]
-        )
-    assert excinfo.value.error == "invalid_grant"
+    assert refresh_obj_2 is None
 
 
 @pytest.mark.asyncio
@@ -871,9 +867,13 @@ async def test_reusing_rotated_out_refresh_revokes_entire_family(
 ):
     """Replay of a rotated_out refresh token: family revoke covers ALL
     access + refresh tokens that share the family_id, including the
-    just-issued new ones."""
+    just-issued new ones.
+
+    Reuse-detection now fires inside ``load_refresh_token`` (so the SDK's
+    pre-checks can't bypass it). The replay leg is therefore JUST the load
+    call — no exchange_refresh_token is needed to trigger the revoke.
+    """
     import logging
-    from mcp.server.auth.provider import TokenError
 
     provider = _make_provider(fresh_store)
     client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
@@ -893,14 +893,14 @@ async def test_reusing_rotated_out_refresh_revokes_entire_family(
     assert await fresh_store.lookup_access_token(rotated.access_token) is not None
     assert await fresh_store.lookup_refresh_token(rotated.refresh_token) is not None
 
-    # Replay: re-present the original (now rotated_out) refresh
-    refresh_replay = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    # Replay: re-present the original (now rotated_out) refresh. The load
+    # call alone must trigger reuse-detection, revoke the family, and
+    # return None (so mcp-sdk surfaces invalid_grant on the SDK side).
     with caplog.at_level(logging.WARNING, logger="langchain_taiga.auth.provider"):
-        with pytest.raises(TokenError) as excinfo:
-            await provider.exchange_refresh_token(
-                client=client_info, refresh_token=refresh_replay, scopes=[]
-            )
-    assert excinfo.value.error == "invalid_grant"
+        refresh_replay = await provider.load_refresh_token(
+            client_info, oauth.refresh_token
+        )
+    assert refresh_replay is None
 
     # ALL four tokens (across both generations of the family) are now gone
     assert await fresh_store.lookup_access_token(oauth.access_token) is None
@@ -913,9 +913,12 @@ async def test_reusing_rotated_out_refresh_revokes_entire_family(
 async def test_reuse_detection_logs_security_warning(
     fresh_store, respx_mock, caplog
 ):
-    """The replay event must surface at WARNING level for audit logs."""
+    """The replay event must surface at WARNING level for audit logs.
+
+    The warning is emitted by ``load_refresh_token`` (the load-path
+    reuse-detection branch added in v2.5.0 — see ``Bug A`` rationale).
+    """
     import logging
-    from mcp.server.auth.provider import TokenError
 
     provider = _make_provider(fresh_store)
     client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
@@ -930,12 +933,9 @@ async def test_reuse_detection_logs_security_warning(
     await provider.exchange_refresh_token(
         client=client_info, refresh_token=first, scopes=[]
     )
-    second = await provider.load_refresh_token(client_info, oauth.refresh_token)
     with caplog.at_level(logging.WARNING, logger="langchain_taiga.auth.provider"):
-        with pytest.raises(TokenError):
-            await provider.exchange_refresh_token(
-                client=client_info, refresh_token=second, scopes=[]
-            )
+        second = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    assert second is None
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert any("reuse detected" in r.getMessage() for r in warnings)
 
@@ -945,9 +945,19 @@ async def test_concurrent_exchange_same_refresh_token_one_wins_other_revokes_fam
     fresh_store, respx_mock
 ):
     """asyncio.gather two exchange calls on the same refresh token.
+
     Atomicity of consume_refresh_token: exactly one observes status=active,
     the other observes status=already_rotated and revokes the family.
-    Net result: even the winner's tokens are revoked."""
+    Net result: even the winner's tokens are revoked by the
+    ``issue_new_generation`` guard (family was revoked between consume and
+    issue).
+
+    Both attempts share a SINGLE pre-fetched RefreshToken object — this
+    matches the mcp-sdk production trace (TokenHandler calls
+    load_refresh_token once, then exchange_refresh_token), and exercises the
+    consume-side defense-in-depth branch rather than the load-side
+    reuse-detection branch.
+    """
     import asyncio
     from mcp.server.auth.provider import TokenError
 
@@ -960,8 +970,9 @@ async def test_concurrent_exchange_same_refresh_token_one_wins_other_revokes_fam
         )
     )
 
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+
     async def attempt():
-        refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
         return await provider.exchange_refresh_token(
             client=client_info, refresh_token=refresh_obj, scopes=[]
         )
@@ -1132,12 +1143,10 @@ async def test_concurrent_exchange_with_cascade_does_not_resurrect_revoked_famil
     )
     await asyncio.sleep(0)  # let slow_task start and reach the await
 
-    # Replay with the now-rotated_out token → triggers reuse-detection → revoke
+    # Replay with the now-rotated_out token → triggers reuse-detection
+    # inside load_refresh_token itself (which returns None after revoking).
     replay_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
-    with pytest.raises(TokenError):
-        await provider.exchange_refresh_token(
-            client=client_info, refresh_token=replay_obj, scopes=[]
-        )
+    assert replay_obj is None
     # Family is now revoked. Release the slow task.
     cascade_gate.set()
     with pytest.raises(TokenError) as excinfo:
@@ -1173,4 +1182,77 @@ async def test_taiga_refresh_transport_error_does_not_revoke_family(
         )
     assert excinfo.value.error == "invalid_grant"
     # Family must still be alive: original access token still resolves
+    assert await fresh_store.lookup_access_token(oauth.access_token) is not None
+
+
+@pytest.mark.asyncio
+async def test_reuse_detection_fires_via_load_before_sdk_scope_check(
+    fresh_store, respx_mock, caplog
+):
+    """Replay with INVALID scope should still revoke the family.
+
+    Before the fix: SDK rejected invalid_scope before reaching our
+    exchange_refresh_token, so reuse-detection never fired and the family
+    stayed alive — an attacker could replay-and-probe indefinitely.
+
+    After the fix: load_refresh_token revokes the family up front on any
+    rotated_out record, regardless of what the SDK does next.
+    """
+    import logging
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth/refresh").mock(
+        return_value=Response(
+            200, json={"auth_token": "jwt_v2", "refresh": "ref_v2"}
+        )
+    )
+
+    # Legitimate first refresh — rotates the original token out
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    rotated = await provider.exchange_refresh_token(
+        client=client_info, refresh_token=refresh_obj, scopes=[]
+    )
+
+    # Replay attempt — just load_refresh_token, which is what the SDK calls
+    # first. Even without calling exchange_refresh_token, the family must
+    # be revoked.
+    with caplog.at_level(logging.WARNING, logger="langchain_taiga.auth.provider"):
+        result = await provider.load_refresh_token(
+            client_info, oauth.refresh_token
+        )
+
+    assert result is None
+    # Family must be wiped: even the just-issued new generation is gone
+    assert await fresh_store.lookup_access_token(rotated.access_token) is None
+    assert await fresh_store.lookup_refresh_token(rotated.refresh_token) is None
+    # WARNING emitted
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("reuse detected" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.asyncio
+async def test_taiga_refresh_malformed_200_does_not_revoke_family(
+    fresh_store, respx_mock
+):
+    """Malformed 200 response from Taiga (missing fields) is treated like
+    any other TaigaRefreshError: family preserved, user re-OAuths."""
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    # Taiga returns 200 but missing auth_token / refresh fields
+    respx_mock.post(
+        "https://taiga.example.test/api/v1/auth/refresh"
+    ).mock(return_value=Response(200, json={"unexpected": "shape"}))
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError) as excinfo:
+        await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+    assert excinfo.value.error == "invalid_grant"
+    # Family preserved
     assert await fresh_store.lookup_access_token(oauth.access_token) is not None

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -526,3 +526,71 @@ async def test_exchange_code_with_redirect_uri_mismatch_raises_invalid_grant(
     with pytest.raises(TokenError) as excinfo:
         await provider.exchange_authorization_code(client_info, tampered)
     assert excinfo.value.error == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_authorization_code_exchange_issues_refresh_token(
+    fresh_store, respx_mock
+):
+    """v2.5.0: exchange_authorization_code must include a refresh_token in
+    the OAuthToken response, persist it in the store, and link both access
+    and refresh under the same family_id."""
+    from mcp.server.auth.provider import AuthorizationParams
+
+    respx_mock.post("https://taiga.example.test/api/v1/auth").mock(
+        return_value=Response(
+            200,
+            json={
+                "auth_token": "alice_jwt",
+                "refresh": "alice_ref",
+                "id": 42,
+                "username": "alice",
+            },
+        )
+    )
+
+    provider = _make_provider(fresh_store)
+    client_info = await provider.register_client(
+        _make_client_info(
+            redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+            client_name="Claude",
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    verifier = "verifier_for_alice_with_enough_entropy_xx"
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    redirect = await provider.authorize(
+        client=client_info,
+        params=AuthorizationParams(
+            state="csrf",
+            scopes=["taiga"],
+            code_challenge=challenge,
+            redirect_uri="https://claude.ai/api/mcp/auth_callback",
+            redirect_uri_provided_explicitly=True,
+        ),
+    )
+    internal_state = redirect.split("internal_state=", 1)[1]
+    code, _ = await provider.complete_login(
+        internal_state=internal_state, username="alice", password="x"
+    )
+    auth_code_obj = await provider.load_authorization_code(client_info, code)
+    oauth_token = await provider.exchange_authorization_code(
+        client=client_info, authorization_code=auth_code_obj
+    )
+
+    assert oauth_token.access_token
+    assert oauth_token.refresh_token is not None
+    assert oauth_token.refresh_token != oauth_token.access_token
+
+    # Both tokens must be in the store with the SAME family_id
+    access_record = await fresh_store.lookup_access_token(oauth_token.access_token)
+    refresh_record = await fresh_store.lookup_refresh_token(oauth_token.refresh_token)
+    assert access_record is not None
+    assert refresh_record is not None
+    assert access_record.family_id == refresh_record.family_id
+    assert access_record.family_id != ""

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -1371,3 +1371,60 @@ async def test_malformed_taiga_response_allows_retry_with_same_refresh_token(
         client=client_info, refresh_token=refresh_obj_retry, scopes=[]
     )
     assert new_oauth.access_token
+
+
+@pytest.mark.asyncio
+async def test_taiga_rejects_refresh_token_revokes_family(
+    fresh_store, respx_mock, caplog
+):
+    """Concurrent-replay scenario: Taiga rejects our cascade with 401
+    (the OTHER request already rotated the upstream refresh). Treat as
+    replay → revoke family per OAuth 2.1 reuse-detection."""
+    import logging
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post(
+        "https://taiga.example.test/api/v1/auth/refresh"
+    ).mock(return_value=Response(401, text="invalid refresh"))
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with caplog.at_level(logging.WARNING, logger="langchain_taiga.auth.provider"):
+        with pytest.raises(TokenError) as excinfo:
+            await provider.exchange_refresh_token(
+                client=client_info, refresh_token=refresh_obj, scopes=[]
+            )
+    assert excinfo.value.error == "invalid_grant"
+
+    # Family was revoked — original access token gone
+    assert await fresh_store.lookup_access_token(oauth.access_token) is None
+    # WARNING emitted naming the concurrent-replay signal
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("concurrent replay" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.asyncio
+async def test_taiga_429_rate_limit_preserves_family(
+    fresh_store, respx_mock
+):
+    """429 is technically 4xx but is transient — must preserve family,
+    matching the 5xx contract so the client can retry the same refresh
+    token after the rate-limit window passes."""
+    from mcp.server.auth.provider import TokenError
+
+    provider = _make_provider(fresh_store)
+    client_info, oauth = await _do_full_auth_flow(provider, fresh_store, respx_mock)
+
+    respx_mock.post(
+        "https://taiga.example.test/api/v1/auth/refresh"
+    ).mock(return_value=Response(429, text="rate limited"))
+
+    refresh_obj = await provider.load_refresh_token(client_info, oauth.refresh_token)
+    with pytest.raises(TokenError):
+        await provider.exchange_refresh_token(
+            client=client_info, refresh_token=refresh_obj, scopes=[]
+        )
+    # Family preserved
+    assert await fresh_store.lookup_access_token(oauth.access_token) is not None

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -854,6 +854,9 @@ async def test_taiga_refresh_failure_preserves_family_and_old_access_token(
                 client=client_info, refresh_token=refresh_obj, scopes=[]
             )
     assert excinfo.value.error == "invalid_grant"
+    # Defense: Taiga's response text must NOT leak into the OAuth client's error
+    # response — operator gets it via the INFO log, client sees a generic message.
+    assert "taiga down" not in str(excinfo.value)
 
     # The original access_token must STILL be valid (family preserved)
     assert await fresh_store.lookup_access_token(oauth.access_token) is not None

--- a/tests/unit_tests/test_provider.py
+++ b/tests/unit_tests/test_provider.py
@@ -832,10 +832,10 @@ async def test_taiga_refresh_failure_preserves_family_and_old_access_token(
     fresh_store, respx_mock, caplog
 ):
     """Cascade failure must NOT revoke the family. Previously-issued access
-    token continues to resolve. Under the cascade-first ordering (Codex P2),
-    the refresh token is also NOT rotated on cascade failure — the client
-    can retry the same refresh token. The "retry succeeds" leg is covered
-    by ``test_transient_cascade_failure_allows_retry_with_same_refresh_token``;
+    token continues to resolve. Under the cascade-first ordering, the
+    refresh token is also NOT rotated on cascade failure — the client can
+    retry the same refresh token. The "retry succeeds" leg is covered by
+    ``test_transient_cascade_failure_allows_retry_with_same_refresh_token``;
     here we just assert the family + access-token survival contract."""
     import logging
     from mcp.server.auth.provider import TokenError
@@ -999,9 +999,9 @@ async def test_concurrent_exchange_same_refresh_token_one_wins_other_revokes_fam
 @pytest.mark.asyncio
 async def test_refresh_cannot_escalate_scopes(fresh_store, respx_mock):
     """A request for a scope superset of the original grant is rejected
-    with invalid_scope. Under the cascade-first ordering (Codex P2), the
-    scope check happens before consume, so the refresh token remains
-    active — the client may retry with a valid scope subset."""
+    with invalid_scope. Under the cascade-first ordering, the scope check
+    happens before consume, so the refresh token remains active — the
+    client may retry with a valid scope subset."""
     from mcp.server.auth.provider import TokenError
 
     provider = _make_provider(fresh_store)
@@ -1124,9 +1124,9 @@ async def test_concurrent_exchange_with_cascade_does_not_resurrect_revoked_famil
     """Race protection: a refresh suspended in Taiga cascade must NOT
     write back tokens after another coroutine revoked the family.
 
-    Under the cascade-first ordering (Codex P2 fix) the cascade happens
-    BEFORE consume_refresh_token, so suspending at the cascade gate leaves
-    the refresh token active in the store. A concurrent replay therefore
+    Under the cascade-first ordering, the cascade happens BEFORE
+    consume_refresh_token, so suspending at the cascade gate leaves the
+    refresh token active in the store. A concurrent replay therefore
     cannot trigger load-path reuse-detection. We instead simulate the
     "family revoked while a refresh is in flight" race directly via
     ``revoke_token_family``. The slow task must abort cleanly — either
@@ -1288,11 +1288,10 @@ async def test_transient_cascade_failure_allows_retry_with_same_refresh_token(
     client can retry with the same refresh token instead of being forced
     through a full OAuth flow.
 
-    Codex P2 fix: cascade-first ordering moves ``consume_refresh_token``
-    after the Taiga cascade succeeds. Without this, the previous fix to
-    revoke families on rotated-out replay turned every transient Taiga
-    blip into a forced re-OAuth (because the second retry attempt would
-    look like a replay)."""
+    The cascade-first ordering puts ``consume_refresh_token`` after the
+    Taiga cascade succeeds. Without this, the revoke-on-rotated-out-replay
+    behavior would turn every transient Taiga blip into a forced re-OAuth
+    (because the second retry attempt would look like a replay)."""
     from mcp.server.auth.provider import TokenError
 
     provider = _make_provider(fresh_store)
@@ -1400,9 +1399,13 @@ async def test_taiga_rejects_refresh_token_revokes_family(
 
     # Family was revoked — original access token gone
     assert await fresh_store.lookup_access_token(oauth.access_token) is None
-    # WARNING emitted naming the concurrent-replay signal
+    # WARNING emitted via the uniform reuse-detection format; the
+    # detection_site marker disambiguates the four entry points (here:
+    # the Taiga-side 4xx).
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("concurrent replay" in r.getMessage() for r in warnings)
+    assert any(
+        "reuse detected (taiga 4xx)" in r.getMessage() for r in warnings
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -355,3 +355,90 @@ async def test_access_token_record_has_family_id():
     record = await store.lookup_access_token("mcp_acc_1")
     assert record is not None
     assert record.family_id == "fam_xyz"
+
+
+@pytest.mark.asyncio
+async def test_store_and_lookup_refresh_token():
+    """Roundtrip: store then lookup returns the persisted record."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+    await store.store_refresh_token(
+        token="ref_1",
+        family_id="fam_1",
+        client_id="c1",
+        taiga_auth_token="t_jwt",
+        taiga_refresh_token="t_ref",
+        taiga_user_id=42,
+        taiga_username="alice",
+        scopes=["taiga"],
+        expires_at=expires_at,
+    )
+    record = await store.lookup_refresh_token("ref_1")
+    assert record is not None
+    assert record.token == "ref_1"
+    assert record.family_id == "fam_1"
+    assert record.client_id == "c1"
+    assert record.taiga_auth_token == "t_jwt"
+    assert record.taiga_refresh_token == "t_ref"
+    assert record.taiga_user_id == 42
+    assert record.taiga_username == "alice"
+    assert record.scopes == ["taiga"]
+    assert record.expires_at == expires_at
+    assert record.rotated_out is False
+
+
+@pytest.mark.asyncio
+async def test_lookup_refresh_token_filters_expired():
+    """Mirror of lookup_access_token: expired records are not returned."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    expired_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    await store.store_refresh_token(
+        token="dead_ref",
+        family_id="fam",
+        client_id="c1",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=expired_at,
+    )
+    assert await store.lookup_refresh_token("dead_ref") is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_refresh_token_returns_rotated_out_records():
+    """Reuse-detection requires seeing rotated_out records on lookup so
+    exchange_refresh_token can route to the family-revoke branch."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+    await store.store_refresh_token(
+        token="ref_rot",
+        family_id="fam",
+        client_id="c1",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=expires_at,
+    )
+    # Manually flip rotated_out to simulate post-rotation state
+    store._refresh_tokens["ref_rot"].rotated_out = True
+    record = await store.lookup_refresh_token("ref_rot")
+    assert record is not None
+    assert record.rotated_out is True
+
+
+@pytest.mark.asyncio
+async def test_lookup_unknown_refresh_token_returns_none():
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    assert await store.lookup_refresh_token("never_minted") is None

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -442,3 +442,140 @@ async def test_lookup_unknown_refresh_token_returns_none():
 
     store = InMemoryStore()
     assert await store.lookup_refresh_token("never_minted") is None
+
+
+@pytest.mark.asyncio
+async def test_consume_refresh_token_active_marks_rotated_out():
+    """First call on a fresh token returns status=active and flips the bit."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    await store.store_refresh_token(
+        token="ref_active",
+        family_id="fam",
+        client_id="c1",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+    result = await store.consume_refresh_token("ref_active")
+    assert result.status == "active"
+    assert result.record is not None
+    assert result.record.token == "ref_active"
+    # rotated_out flag was flipped in place
+    assert store._refresh_tokens["ref_active"].rotated_out is True
+
+
+@pytest.mark.asyncio
+async def test_consume_refresh_token_already_rotated_returns_replay_status():
+    """Second consume on the same token returns status=already_rotated."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    await store.store_refresh_token(
+        token="ref_dup",
+        family_id="fam",
+        client_id="c1",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+    first = await store.consume_refresh_token("ref_dup")
+    assert first.status == "active"
+    second = await store.consume_refresh_token("ref_dup")
+    assert second.status == "already_rotated"
+    assert second.record is not None
+    assert second.record.family_id == "fam"
+
+
+@pytest.mark.asyncio
+async def test_consume_refresh_token_expired_returns_expired_status():
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    await store.store_refresh_token(
+        token="ref_exp",
+        family_id="fam",
+        client_id="c1",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    result = await store.consume_refresh_token("ref_exp")
+    assert result.status == "expired"
+
+
+@pytest.mark.asyncio
+async def test_consume_refresh_token_not_found():
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    result = await store.consume_refresh_token("never_minted")
+    assert result.status == "not_found"
+    assert result.record is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_family_removes_all_tokens_in_family():
+    """Family-revoke wipes every access AND refresh token sharing family_id."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    exp_a = datetime.now(timezone.utc) + timedelta(hours=1)
+    exp_r = datetime.now(timezone.utc) + timedelta(days=30)
+    # Family A: 2 access tokens, 2 refresh tokens (one rotated_out, one active)
+    for tok in ("acc_a1", "acc_a2"):
+        await store.store_access_token(
+            token=tok,
+            family_id="fam_A",
+            taiga_auth_token="t",
+            taiga_refresh_token="r",
+            taiga_user_id=1,
+            taiga_username="x",
+            client_id="c1",
+            scopes=["taiga"],
+            expires_at=exp_a,
+        )
+    for tok in ("ref_a1", "ref_a2"):
+        await store.store_refresh_token(
+            token=tok,
+            family_id="fam_A",
+            client_id="c1",
+            taiga_auth_token="t",
+            taiga_refresh_token="r",
+            taiga_user_id=1,
+            taiga_username="x",
+            scopes=["taiga"],
+            expires_at=exp_r,
+        )
+    store._refresh_tokens["ref_a1"].rotated_out = True
+    # Unrelated family B: must survive
+    await store.store_access_token(
+        token="acc_b1",
+        family_id="fam_B",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=2,
+        taiga_username="bob",
+        client_id="c2",
+        scopes=["taiga"],
+        expires_at=exp_a,
+    )
+    revoked = await store.revoke_token_family("fam_A")
+    assert revoked == 4
+    # Family A wiped
+    for tok in ("acc_a1", "acc_a2"):
+        assert await store.lookup_access_token(tok) is None
+    for tok in ("ref_a1", "ref_a2"):
+        assert await store.lookup_refresh_token(tok) is None
+    # Family B intact
+    assert await store.lookup_access_token("acc_b1") is not None

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -331,3 +331,27 @@ async def test_cleanup_expired_purges_old_records():
     assert await store.lookup_access_token("dead_1") is None
     assert await store.lookup_access_token("dead_2") is None
     assert await store.lookup_access_token("live") is not None
+
+
+@pytest.mark.asyncio
+async def test_access_token_record_has_family_id():
+    """Each access token belongs to a refresh-family. The family_id is the
+    revocation handle when reuse-detection fires."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    await store.store_access_token(
+        token="mcp_acc_1",
+        family_id="fam_xyz",
+        taiga_auth_token="taiga_jwt",
+        taiga_refresh_token="taiga_ref",
+        taiga_user_id=1,
+        taiga_username="alice",
+        client_id="c1",
+        scopes=["taiga"],
+        expires_at=expires_at,
+    )
+    record = await store.lookup_access_token("mcp_acc_1")
+    assert record is not None
+    assert record.family_id == "fam_xyz"

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -655,9 +655,9 @@ async def test_cleanup_expired_sweeps_refresh_tokens():
 
     purged = await store.cleanup_expired()
     assert purged == 2
-    assert "fresh" in store._refresh_tokens
-    assert "stale_active" not in store._refresh_tokens
-    assert "stale_rotated" not in store._refresh_tokens
+    assert await store.lookup_refresh_token("fresh") is not None
+    assert await store.lookup_refresh_token("stale_active") is None
+    assert await store.lookup_refresh_token("stale_rotated") is None
 
 
 @pytest.mark.asyncio
@@ -668,7 +668,7 @@ async def test_cleanup_expired_purges_old_revoked_family_tombstones():
     from langchain_taiga.auth.store import InMemoryStore
 
     store = InMemoryStore()
-    # Inject a stale and a fresh tombstone directly
+    # Direct private-state injection: no public API to seed an aged tombstone.
     stale_ts = datetime.now(timezone.utc) - timedelta(days=31)
     fresh_ts = datetime.now(timezone.utc) - timedelta(days=1)
     store._revoked_families["fam_stale"] = stale_ts

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -413,7 +413,9 @@ async def test_lookup_refresh_token_filters_expired():
 @pytest.mark.asyncio
 async def test_lookup_refresh_token_returns_rotated_out_records():
     """Reuse-detection requires seeing rotated_out records on lookup so
-    exchange_refresh_token can route to the family-revoke branch."""
+    load_refresh_token can inspect the flag and revoke the family
+    directly (returning None to mcp-sdk). Filtering rotated_out at the
+    store layer would hide the replay signal."""
     from langchain_taiga.auth.store import InMemoryStore
 
     store = InMemoryStore()

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -656,3 +656,23 @@ async def test_cleanup_expired_sweeps_refresh_tokens():
     assert "fresh" in store._refresh_tokens
     assert "stale_active" not in store._refresh_tokens
     assert "stale_rotated" not in store._refresh_tokens
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_purges_old_revoked_family_tombstones():
+    """Tombstones older than REFRESH_TOKEN_TTL are no longer useful for
+    reuse-detection (every refresh token in the family has expired by
+    then) and must be swept to bound memory growth."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    # Inject a stale and a fresh tombstone directly
+    stale_ts = datetime.now(timezone.utc) - timedelta(days=31)
+    fresh_ts = datetime.now(timezone.utc) - timedelta(days=1)
+    store._revoked_families["fam_stale"] = stale_ts
+    store._revoked_families["fam_fresh"] = fresh_ts
+
+    purged = await store.cleanup_expired()
+    assert purged >= 1
+    assert "fam_stale" not in store._revoked_families
+    assert "fam_fresh" in store._revoked_families

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -579,3 +579,27 @@ async def test_revoke_token_family_removes_all_tokens_in_family():
         assert await store.lookup_refresh_token(tok) is None
     # Family B intact
     assert await store.lookup_access_token("acc_b1") is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_family_with_empty_family_id_is_a_noop():
+    """Defense: an empty-string family_id (e.g. from a legacy/unset field)
+    must NOT purge records whose family_id also defaults to ''."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    # Legacy record with default ""
+    await store.store_access_token(
+        token="legacy",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        client_id="c",
+        scopes=["taiga"],
+        expires_at=expires_at,
+    )  # family_id defaults to ""
+    revoked = await store.revoke_token_family("")
+    assert revoked == 0
+    assert await store.lookup_access_token("legacy") is not None

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -603,3 +603,56 @@ async def test_revoke_token_family_with_empty_family_id_is_a_noop():
     revoked = await store.revoke_token_family("")
     assert revoked == 0
     assert await store.lookup_access_token("legacy") is not None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_sweeps_refresh_tokens():
+    """Both active and rotated_out refresh tokens should be purged when
+    expired; fresh tokens survive."""
+    from langchain_taiga.auth.store import InMemoryStore
+
+    store = InMemoryStore()
+    now = datetime.now(timezone.utc)
+    fresh_exp = now + timedelta(days=30)
+    stale_exp = now - timedelta(seconds=1)
+
+    await store.store_refresh_token(
+        token="fresh",
+        family_id="f",
+        client_id="c",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=fresh_exp,
+    )
+    await store.store_refresh_token(
+        token="stale_active",
+        family_id="f",
+        client_id="c",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=stale_exp,
+    )
+    await store.store_refresh_token(
+        token="stale_rotated",
+        family_id="f",
+        client_id="c",
+        taiga_auth_token="t",
+        taiga_refresh_token="r",
+        taiga_user_id=1,
+        taiga_username="x",
+        scopes=["taiga"],
+        expires_at=stale_exp,
+    )
+    store._refresh_tokens["stale_rotated"].rotated_out = True
+
+    purged = await store.cleanup_expired()
+    assert purged == 2
+    assert "fresh" in store._refresh_tokens
+    assert "stale_active" not in store._refresh_tokens
+    assert "stale_rotated" not in store._refresh_tokens


### PR DESCRIPTION
## Summary

Implements OAuth 2.1 refresh-token rotation with reuse-detection for the remote MCP server, fixing the hourly "Verbindung abgelaufen" disconnect that all connected MCP clients (claude.ai, VSCode, Claude Desktop) currently experience.

## Why

- v1 issued a 1-hour access token and **no refresh token** — clients fell back to a full OAuth flow at every expiry
- claude.ai disconnects every ~1 hour and forces the user back through the login page
- This shifts the re-auth frequency from "every hour" to "every pod restart" (i.e. Helm deploy)

## What changed

**Storage layer (`auth/store.py`)**
- New `RefreshTokenRecord` dataclass + `_refresh_tokens` dict
- `AccessTokenRecord` gains a `family_id` field linking it to its refresh-rotation lineage
- `consume_refresh_token` — atomic lookup + state transition (no awaits between read and mutation, single-threaded asyncio guarantees race-safety)
- `revoke_token_family` — wipes every record sharing a `family_id`; guarded against accidental `""` mass-revoke
- `issue_new_generation` — atomic two-write issuance that refuses to resurrect a family revoked while the caller was suspended in cascade
- `_revoked_families` dict (family_id → revoked_at) marks revoked families permanently to defeat resurrection races; tombstones swept by `cleanup_expired` after REFRESH_TOKEN_TTL
- `cleanup_expired` extended to sweep refresh tokens AND old tombstones

**Provider layer (`auth/provider.py`)**
- `REFRESH_TOKEN_TTL = 30 days` (access TTL unchanged at 1 hour — OAuth 2.1 best practice for public clients)
- `exchange_authorization_code` mints a refresh token + family alongside the access token
- `load_refresh_token` (replaces v1 stub) triggers reuse-detection on `rotated_out` records — necessary because mcp-sdk's `TokenHandler` runs scope/PKCE validation **before** `exchange_refresh_token` is called
- `exchange_refresh_token` (replaces `NotImplementedError`):
  - Order: **lookup → validate → cascade → consume → issue** (cascade-first so transient failures leave the refresh token retriable)
  - Atomic `consume_refresh_token` discriminates {not_found, expired, already_rotated, active}
  - Cascade to Taiga's `/api/v1/auth/refresh` — rotated Taiga JWT lands in the new generation's records
  - **Taiga 4xx response** (typically 401) is treated as a concurrent-replay signal → family revoke
  - **Taiga 5xx / 429 / network / malformed-200** preserves the family; client retries the same refresh token; transient outages don't kick everyone out
  - Reuse-detection (`already_rotated` branch) is defense-in-depth; primary detection is in `load_refresh_token`
  - Scope-subset enforcement (no escalation)
  - Cross-client check (defense-in-depth — mcp-sdk also filters earlier)

**Taiga client (`auth/taiga_client.py`)**
- New `TaigaRefreshTokenInvalidError` subclass of `TaigaRefreshError` distinguishes "Taiga says this refresh token is invalid" (4xx) from generic transient errors (5xx/network/malformed-200/429)
- `refresh_taiga_token` wraps `httpx.RequestError` + malformed-200 into `TaigaRefreshError`, so transient errors flow through the cascade-failure handler instead of bubbling as 500

## Validation

- 223 tests pass (`pytest --disable-socket --allow-unix-socket tests/unit_tests/`)
- 26 new tests cover: family minting, rotation, reuse-detection (incl. SDK-bypass + concurrent-replay-via-Taiga-401), cross-client, scope escalation/subset, cascade failure preserves family vs. revokes family (depending on 4xx vs 5xx), transient retry works, malformed-200 preserves family, concurrent-exchange race, cleanup-loop sweeps refresh tokens AND tombstones, family-id resurrection-after-revoke is prevented
- Codex pre-push review: 5 rounds, all P1/P2/P3 findings addressed (atomic consume + family resurrection race + SDK-bypass + malformed-response + auth-vs-transport mislabel + cascade-first reorder + 4xx-as-reuse-signal + tombstone cleanup). One deferred finding documented as out-of-scope: per-client `grant_types` enforcement at refresh-token issuance (impacts no real consumer; would require persisting more DCR fields).

## Risk / follow-up

- In-memory store: pod restart still wipes all tokens, forcing all users to re-OAuth once. This is unchanged from v1 and documented in the AGENTS.md.
- All real consumers (claude.ai, VSCode, Claude Desktop) include `refresh_token` in their `grant_types` DCR field, so the deferred `grant_types` filter has no behavioral impact.
- Downstream: bump `TAIGA_MCP_VERSION` in `taiga` repo's `Jenkinsfile` from 2.4.0 → 2.5.0 after this merges and PyPI publishes.

## Test plan

- [x] Local: `pytest --disable-socket --allow-unix-socket tests/unit_tests/` → 223 passed, 1 skipped
- [ ] CI: `ci_publish.yml` runs the same suite + auto-publishes to PyPI on merge
- [ ] Post-merge: PyPI `/simple/` index lag ~1 min — verify with `pip index versions langchain-taiga` before chained Jenkins build
- [ ] Live smoke: leave claude.ai connected > 1 hour after the `taiga` Helm release rolls out, confirm no re-auth prompt fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Codex-Review: gpt-5.5 xhigh normal, 7 findings addressed