### PR TITLE
Add add_attachment_inline_by_ref_tool (2.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@
 
 The package ships three things in one install:
 
-1. **20 LangChain tools** for Taiga (entities, wiki, custom attributes, members, sprint planning).
+1. **21 LangChain tools** for Taiga (entities, wiki, custom attributes, members, sprint planning).
 2. **A `TaigaToolkit`** that bundles them for one-line LangChain agent setup.
 3. **An MCP server in two flavours:**
    - **Stdio mode** — single-user, local credentials in env vars. For Claude Desktop, Claude Code, VSCode local.
    - **Remote mode** — multi-tenant HTTP server with OAuth 2.1 + PKCE + Dynamic Client Registration. For [claude.ai Custom Connectors](https://support.anthropic.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp), [VSCode Web](https://vscode.dev/), Claude Desktop with HTTP transport, etc. Each user signs in with their own Taiga credentials; the server stores no static API key.
 
-The 20 tools:
+The 21 tools:
 
 - **`create_entity_tool`**: Creates user stories, tasks and issues in Taiga.
 - **`search_entities_tool`**: Searches for user stories, tasks and issues in Taiga. Returns `{matches, count, max_results, truncated}`. Supports `max_results` and `include_custom_attributes` (default `False` — opt-in to avoid an N+1 fetch storm). Date filters are tz-aware.
 - **`get_entity_by_ref_tool`**: Gets a user story, task or issue by reference. For user stories, the response also includes a `points` field (`{role_name: value}` shape, symmetric to `set_userstory_points_tool`'s input) so a read + write round-trip stays in the same vocabulary.
 - **`update_entity_by_ref_tool`**: Updates a user story, task or issue by reference.
 - **`add_comment_by_ref_tool`**: Adds a comment to a user story, task or issue.
-- **`add_attachment_by_ref_tool`**: Adds an attachment to a user story, task or issue.
+- **`add_attachment_by_ref_tool`**: Adds an attachment to a user story, task or issue by downloading a **public URL** (the server fetches it via `requests.get`).
+- **`add_attachment_inline_by_ref_tool`**: Uploads a **local file** as an attachment by inlining its bytes as base64. Symmetric to `get_attachment_by_ref_tool`. Use when the file lives on the calling client (Claude Code, claude.ai) and shouldn't be exposed via a public URL. Refuses payloads whose decoded size exceeds `TAIGA_MAX_INLINE_ATTACHMENT_BYTES` (default 10 MB).
 - **`list_attachments_by_ref_tool`**: List all attachments on an entity with fresh signed download URLs. URL tokens from the Taiga UI/webhook diff expire after ~6 min; this tool re-mints them on every call.
 - **`get_attachment_by_ref_tool`**: Fetch a specific attachment by ID and return its content base64-encoded inline. Refuses files larger than `TAIGA_MAX_INLINE_ATTACHMENT_BYTES` (default 10 MB) — for larger files use `list_attachments_by_ref_tool` and `curl` the `download_url` out-of-band.
 - **`promote_issue_to_userstory_tool`**: Promotes an issue to a user story, preserving comments and history.
@@ -98,7 +99,7 @@ search_entities_tool.invoke({
 whoami_tool.invoke({})
 ```
 
-For the full set of 20 tools see the list at the top of this README, the docstrings in [`taiga_tools.py`](./langchain_taiga/tools/taiga_tools.py), or just grab them all via the toolkit below.
+For the full set of 21 tools see the list at the top of this README, the docstrings in [`taiga_tools.py`](./langchain_taiga/tools/taiga_tools.py), or just grab them all via the toolkit below.
 
 ### Using the Toolkit
 
@@ -113,7 +114,7 @@ tools = toolkit.get_tools()
 
 ## MCP Server
 
-The package ships an MCP server powered by [`fastmcp`](https://pypi.org/project/fastmcp/). All 20 tools above are exposed as MCP tools without changing their behaviour. There are **two transport modes** with different auth models:
+The package ships an MCP server powered by [`fastmcp`](https://pypi.org/project/fastmcp/). All 21 tools above are exposed as MCP tools without changing their behaviour. There are **two transport modes** with different auth models:
 
 | Mode | Transport | Auth | Use case |
 |---|---|---|---|

--- a/langchain_taiga/__init__.py
+++ b/langchain_taiga/__init__.py
@@ -2,6 +2,7 @@ from importlib import metadata
 
 from langchain_taiga.tools.taiga_tools import (
     add_attachment_by_ref_tool,
+    add_attachment_inline_by_ref_tool,
     add_comment_by_ref_tool,
     create_entity_tool,
     create_wiki_page_tool,
@@ -27,6 +28,7 @@ del metadata  # optional, avoids polluting the results of dir(__package__)
 
 __all__ = [
     "add_attachment_by_ref_tool",
+    "add_attachment_inline_by_ref_tool",
     "add_comment_by_ref_tool",
     "create_entity_tool",
     "create_wiki_page_tool",

--- a/langchain_taiga/toolkits.py
+++ b/langchain_taiga/toolkits.py
@@ -6,6 +6,7 @@ from langchain_core.tools import BaseTool, BaseToolkit
 
 from langchain_taiga.tools.taiga_tools import (
     add_attachment_by_ref_tool,
+    add_attachment_inline_by_ref_tool,
     add_comment_by_ref_tool,
     create_entity_tool,
     create_wiki_page_tool,
@@ -99,6 +100,7 @@ class TaigaToolkit(BaseToolkit):
             update_entity_by_ref_tool,
             add_comment_by_ref_tool,
             add_attachment_by_ref_tool,
+            add_attachment_inline_by_ref_tool,
             list_attachments_by_ref_tool,
             get_attachment_by_ref_tool,
             promote_issue_to_userstory_tool,

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -8,6 +8,7 @@ import re
 import tempfile
 import threading
 from datetime import datetime, timedelta, timezone
+from pathlib import PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -39,6 +40,16 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 # out-of-band. ENV-overridable so we can tune without a re-release if
 # claude.ai / FastMCP enforces a lower payload cap.
 MAX_INLINE_ATTACHMENT_BYTES = int(os.getenv("TAIGA_MAX_INLINE_ATTACHMENT_BYTES", 10 * 1024 * 1024))
+
+# Translation table used by ``add_attachment_inline_by_ref_tool`` to
+# strip ASCII whitespace from inline base64 input in a single pass.
+# ``str.translate`` allocates exactly one new string (length ≤ input),
+# unlike ``str.split() + "".join()`` which materializes a list of
+# substring objects — pathological inputs interleaving single chars
+# with whitespace (``"A\nA\nA..."``) generate millions of substring
+# objects (~50 bytes each of header overhead in CPython), defeating
+# the size guard and OOM-ing the MCP worker.
+_INLINE_B64_WHITESPACE_DELETE = str.maketrans("", "", " \t\n\r\v\f")
 
 if OPENAI_API_KEY:
     small_llm = ChatOpenAI(model="gpt-5.1")
@@ -1737,6 +1748,260 @@ def add_attachment_by_ref_tool(
     finally:
         if temp_file_path and os.path.exists(temp_file_path):
             os.remove(temp_file_path)
+
+    att_dict = attachment.to_dict()
+    att_dict.pop("url", None)
+    return json.dumps(
+        {
+            "added": True,
+            "project": project.name,
+            "type": norm_type,
+            "ref": entity_ref,
+            "url": f"{TAIGA_URL}/project/{project_slug}/{norm_type}/{entity_ref}",
+            "attachments": att_dict,
+        },
+        indent=2,
+    )
+
+
+@tool(parse_docstring=True)
+def add_attachment_inline_by_ref_tool(
+    project_slug: str,
+    entity_ref: int,
+    entity_type: str,
+    attachment_filename: str,
+    attachment_content_base64: str,
+    description: str = "",
+) -> str:
+    """
+    Upload a LOCAL file as an attachment to a Taiga entity by inlining
+    its bytes as base64. Symmetric counterpart to
+    ``get_attachment_by_ref_tool``: where that one returns inline-base64
+    DOWN, this one accepts inline-base64 UP.
+
+    Use when:
+      - You have a file on the calling client (Claude Code, claude.ai)
+        and need to attach it to a Taiga ticket without exposing it via
+        a public URL or a paste service.
+      - You produced a file in-session (analysis output, screenshot,
+        diff dump, log capture) and need to ship it to a ticket in
+        one tool call.
+
+    The Taiga-side ``content_type`` is determined by the filename
+    extension (Taiga sniffs from the uploaded file's name). Pass the
+    desired extension via ``attachment_filename`` (e.g. ``foo.md``,
+    ``screenshot.png``) — there is no separate MIME-type parameter,
+    because ``python-taiga``'s multipart upload does not expose one.
+
+    Refuses payloads whose decoded size exceeds
+    ``TAIGA_MAX_INLINE_ATTACHMENT_BYTES`` (default 10 MB). Above that
+    threshold, host the file externally and use
+    ``add_attachment_by_ref_tool`` with the resulting URL.
+
+    Args:
+        project_slug: From URL path (e.g. 'shikenso-development').
+        entity_ref: Visible number in entity URL (e.g. 7398).
+        entity_type: 'task', 'userstory', 'issue', or 'epic'.
+        attachment_filename: File name to display in Taiga (e.g.
+            'handover.md'). Path components are stripped — only the
+            basename reaches Taiga. Both POSIX and Windows separators
+            are stripped (a Windows client passing a backslash path
+            still uploads as the bare filename).
+        attachment_content_base64: File bytes, base64-encoded (standard
+            alphabet, padded). Plain text files should be encoded the
+            same way — no URL-safe variant.
+        description: Optional attachment description shown in Taiga.
+
+    Returns:
+        JSON string with id, name, size for the newly created attachment.
+        Errors: 400 (entity_type / empty filename / invalid base64 /
+        empty payload), 404 (project/entity not found), 413 (decoded
+        size > cap), 500 (Taiga upload failed).
+
+    Examples:
+        add_attachment_inline_by_ref_tool("shikenso-development", 7398,
+            "issue", "log.txt", "aGVsbG8=")
+    """
+    norm_type = normalize_entity_type(entity_type)
+    if not norm_type:
+        return json.dumps(
+            {"error": f"Invalid entity type '{entity_type}'", "code": 400},
+            indent=2,
+        )
+
+    # Strip any path components so a caller can't smuggle "../etc/passwd"
+    # or weird path-shaped names into Taiga's attachment display name.
+    # ``PureWindowsPath`` handles BOTH POSIX ``/`` and Windows ``\`` as
+    # separators (unlike ``os.path.basename`` which only knows the host
+    # OS's separator — on the Linux MCP pod that would let a Windows
+    # client smuggle ``C:\\tmp\\foo.txt`` through as the full path).
+    safe_filename = PureWindowsPath(attachment_filename or "").name
+    # Reject empty AND pure dot-segments. ``PureWindowsPath('..').name``
+    # is ``'..'`` (and ``'foo/..'``.name is also ``'..'``), which would
+    # later crash ``open(os.path.join(tmpdir, '..'), 'wb')`` with
+    # ``IsADirectoryError`` → bubbled up as a misleading 500. Treat
+    # those as user errors with a precise 400.
+    if not safe_filename or safe_filename in {".", ".."}:
+        return json.dumps(
+            {
+                "error": (
+                    "attachment_filename must resolve to a non-empty, "
+                    "non-dot basename (path components are not allowed)"
+                ),
+                "code": 400,
+            },
+            indent=2,
+        )
+
+    # Two-stage size guard.
+    #
+    # Stage 1: cheap O(1) raw-length ceiling on the input. Whitespace
+    # stripping in stage 2 allocates O(input) extra memory (one list of
+    # substrings + one joined string). For wrapped GNU-base64 input of
+    # a 10 MB file (~13.5 MB raw chars including newlines), the
+    # cleaned form is well under the 10 MB cap — but we MUST refuse
+    # arbitrarily-large raw inputs BEFORE the split allocation, or a
+    # 1 GB whitespace-padded payload would still OOM the worker.
+    #
+    # The threshold is ``cap * 1.5`` worth of raw chars (i.e. raw
+    # upper-bound > cap * 1.5). That window is wide enough to absorb
+    # all common base64 wrapping styles (GNU's 76-char wrap is ~1.3%
+    # overhead; MIME 7-bit transfer ~3%; we allow up to 50% as buffer)
+    # AND narrow enough that the subsequent split allocation is
+    # bounded by ~2 × cap of memory.
+    raw_upper_bound = len(attachment_content_base64) * 3 // 4
+    if raw_upper_bound > MAX_INLINE_ATTACHMENT_BYTES * 3 // 2:
+        return json.dumps(
+            {
+                "error": (
+                    f"Payload exceeds TAIGA_MAX_INLINE_ATTACHMENT_BYTES="
+                    f"{MAX_INLINE_ATTACHMENT_BYTES} (raw upper-bound "
+                    f"estimate {raw_upper_bound} bytes). Host the file "
+                    f"externally and use add_attachment_by_ref_tool with "
+                    f"the URL."
+                ),
+                "code": 413,
+                "size": raw_upper_bound,
+                "max_bytes": MAX_INLINE_ATTACHMENT_BYTES,
+            },
+            indent=2,
+        )
+
+    # Stage 2: strip ASCII whitespace and refine the bound. GNU
+    # ``base64`` and many MIME tools wrap encoded output at 76 chars
+    # with newlines, and a single trailing ``\n`` is common in pasted
+    # payloads. With ``validate=True`` ``b64decode`` would reject these
+    # — that's a usability footgun for a "upload local file" tool.
+    # Stripping the whitespace:
+    #   - tightens the upper-bound estimate (avoids counting newlines
+    #     against the cap)
+    #   - keeps ``validate=True`` strict against actual invalid chars
+    #   - matches the de-facto base64 contract that "newlines may
+    #     appear in the encoded data" (RFC 4648 §3.3).
+    #
+    # Uses ``str.translate`` (single allocation of length ≤ input) NOT
+    # ``str.split() + "".join()`` — the latter materializes a list of
+    # substring objects (~50 bytes header each in CPython) for inputs
+    # like ``"A\nA\nA..."``, which can amplify a 20 MB input into
+    # hundreds of MB of resident heap and OOM the worker even though
+    # the cleaned form is small.
+    #
+    # The cleaned upper-bound check uses ``> MAX + 3`` (3-byte slack
+    # absorbs padding + alignment overshoot of the loose formula) so
+    # exactly-at-cap valid payloads still go through — the post-decode
+    # ``>`` check below catches anything genuinely over.
+    b64_clean = attachment_content_base64.translate(_INLINE_B64_WHITESPACE_DELETE)
+    b64_upper_bound = len(b64_clean) * 3 // 4
+    if b64_upper_bound > MAX_INLINE_ATTACHMENT_BYTES + 3:
+        return json.dumps(
+            {
+                "error": (
+                    f"Payload exceeds TAIGA_MAX_INLINE_ATTACHMENT_BYTES="
+                    f"{MAX_INLINE_ATTACHMENT_BYTES} (upper-bound estimate "
+                    f"{b64_upper_bound} bytes). Host the file externally "
+                    f"and use add_attachment_by_ref_tool with the URL."
+                ),
+                "code": 413,
+                "size": b64_upper_bound,
+                "max_bytes": MAX_INLINE_ATTACHMENT_BYTES,
+            },
+            indent=2,
+        )
+
+    try:
+        payload = base64.b64decode(b64_clean, validate=True)
+    except Exception as e:
+        return json.dumps(
+            {
+                "error": f"attachment_content_base64 is not valid base64: {str(e)}",
+                "code": 400,
+            },
+            indent=2,
+        )
+
+    if not payload:
+        return json.dumps(
+            {"error": "attachment_content_base64 decodes to zero bytes", "code": 400},
+            indent=2,
+        )
+
+    # Post-decode cap as defense-in-depth. With the exact pre-decode
+    # formula above this branch is effectively unreachable for valid
+    # b64, but kept identical in shape to ``get_attachment_by_ref_tool``'s
+    # mid-stream guard so reviewers don't have to reason about which
+    # tools enforce the cap which way.
+    if len(payload) > MAX_INLINE_ATTACHMENT_BYTES:
+        return json.dumps(
+            {
+                "error": (
+                    f"Decoded payload is {len(payload)} bytes, exceeds "
+                    f"TAIGA_MAX_INLINE_ATTACHMENT_BYTES="
+                    f"{MAX_INLINE_ATTACHMENT_BYTES}."
+                ),
+                "code": 413,
+                "size": len(payload),
+                "max_bytes": MAX_INLINE_ATTACHMENT_BYTES,
+            },
+            indent=2,
+        )
+
+    project = get_project(project_slug)
+    if not project:
+        return json.dumps(
+            {"error": f"Project '{project_slug}' not found", "code": 404},
+            indent=2,
+        )
+
+    try:
+        entity = fetch_entity(project, norm_type, entity_ref)
+    except Exception as e:
+        return json.dumps(
+            {"error": f"Error fetching entity: {str(e)}", "code": 500},
+            indent=2,
+        )
+    if not entity:
+        return json.dumps(
+            {"error": f"{entity_type} {entity_ref} not found", "code": 404},
+            indent=2,
+        )
+
+    # ``TemporaryDirectory`` + joined path means python-taiga's
+    # ``Attachments._new_resource`` will use ``os.path.basename(file_path)``
+    # — i.e. ``safe_filename`` — as the multipart ``name``, so the
+    # attachment shows up in Taiga with the caller's filename instead of
+    # a ``tmpXXXX`` random suffix (the failure mode of the existing
+    # ``add_attachment_by_ref_tool``).
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, safe_filename)
+            with open(file_path, "wb") as f:
+                f.write(payload)
+            attachment = entity.attach(file_path, description=description)
+    except Exception as e:
+        return json.dumps(
+            {"error": f"Attachment upload failed: {str(e)}", "code": 500},
+            indent=2,
+        )
 
     att_dict = attachment.to_dict()
     att_dict.pop("url", None)
@@ -3724,6 +3989,7 @@ def _register_mcp_tools(mcp_instance) -> None:
         {
             id(sort_kanban_by_rice_tool),
             id(add_attachment_by_ref_tool),
+            id(add_attachment_inline_by_ref_tool),
             id(list_attachments_by_ref_tool),
             id(get_attachment_by_ref_tool),
         }
@@ -3736,6 +4002,7 @@ def _register_mcp_tools(mcp_instance) -> None:
         update_entity_by_ref_tool,
         add_comment_by_ref_tool,
         add_attachment_by_ref_tool,
+        add_attachment_inline_by_ref_tool,
         list_attachments_by_ref_tool,
         get_attachment_by_ref_tool,
         promote_issue_to_userstory_tool,

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -1813,10 +1813,13 @@ def add_attachment_inline_by_ref_tool(
         description: Optional attachment description shown in Taiga.
 
     Returns:
-        JSON string with id, name, size for the newly created attachment.
-        Errors: 400 (entity_type / empty filename / invalid base64 /
-        empty payload), 404 (project/entity not found), 413 (decoded
-        size > cap), 500 (Taiga upload failed).
+        JSON envelope mirroring ``add_attachment_by_ref_tool``:
+        ``{added, project, type, ref, url, attachments}`` where
+        ``attachments`` is the python-taiga attachment dict
+        (id, name, size, description, …) with the signed-url field
+        stripped. Errors: 400 (entity_type / empty filename / invalid
+        base64 / empty payload), 404 (project/entity not found), 413
+        (decoded size > cap), 500 (Taiga upload failed).
 
     Examples:
         add_attachment_inline_by_ref_tool("shikenso-development", 7398,
@@ -1855,19 +1858,20 @@ def add_attachment_inline_by_ref_tool(
 
     # Two-stage size guard.
     #
-    # Stage 1: cheap O(1) raw-length ceiling on the input. Whitespace
-    # stripping in stage 2 allocates O(input) extra memory (one list of
-    # substrings + one joined string). For wrapped GNU-base64 input of
-    # a 10 MB file (~13.5 MB raw chars including newlines), the
-    # cleaned form is well under the 10 MB cap — but we MUST refuse
-    # arbitrarily-large raw inputs BEFORE the split allocation, or a
-    # 1 GB whitespace-padded payload would still OOM the worker.
+    # Stage 1: cheap O(1) raw-length ceiling on the input. The
+    # whitespace-stripping ``str.translate`` call in stage 2 still
+    # allocates O(input) extra memory (one new string of length ≤
+    # original). For wrapped GNU-base64 input of a 10 MB file
+    # (~13.5 MB raw chars including newlines), the cleaned form is
+    # well under the 10 MB cap — but we MUST refuse arbitrarily-large
+    # raw inputs BEFORE that allocation, or a 1 GB whitespace-padded
+    # payload would still OOM the worker.
     #
     # The threshold is ``cap * 1.5`` worth of raw chars (i.e. raw
     # upper-bound > cap * 1.5). That window is wide enough to absorb
     # all common base64 wrapping styles (GNU's 76-char wrap is ~1.3%
     # overhead; MIME 7-bit transfer ~3%; we allow up to 50% as buffer)
-    # AND narrow enough that the subsequent split allocation is
+    # AND narrow enough that the subsequent translate allocation is
     # bounded by ~2 × cap of memory.
     raw_upper_bound = len(attachment_content_base64) * 3 // 4
     if raw_upper_bound > MAX_INLINE_ATTACHMENT_BYTES * 3 // 2:
@@ -1945,11 +1949,14 @@ def add_attachment_inline_by_ref_tool(
             indent=2,
         )
 
-    # Post-decode cap as defense-in-depth. With the exact pre-decode
-    # formula above this branch is effectively unreachable for valid
-    # b64, but kept identical in shape to ``get_attachment_by_ref_tool``'s
-    # mid-stream guard so reviewers don't have to reason about which
-    # tools enforce the cap which way.
+    # Post-decode cap — precise ``>`` check on the actual decoded
+    # length. This is reachable: the stage-2 pre-decode bound allows a
+    # 3-byte slack (``MAX + 3``) to absorb padding + alignment
+    # overshoot of the loose ``len(b64) * 3 // 4`` formula, so valid
+    # b64 whose decoded length is 1–3 bytes over the cap will slip past
+    # the pre-check and land here. Kept identical in shape to
+    # ``get_attachment_by_ref_tool``'s mid-stream guard so reviewers
+    # don't have to reason about which tools enforce the cap which way.
     if len(payload) > MAX_INLINE_ATTACHMENT_BYTES:
         return json.dumps(
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.6.0"
-description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5 adds OAuth refresh-token rotation with reuse-detection for stable long-lived connections. v2.6 adds attachment list/get tools for reading existing ticket attachments."
+version = "2.7.0"
+description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5 adds OAuth refresh-token rotation with reuse-detection for stable long-lived connections. v2.6 adds attachment list/get tools for reading existing ticket attachments. v2.7 adds inline-base64 file upload so MCP clients can attach local files without exposing them via a public URL."
 authors = []
 readme = "README.md"
 repository = "https://github.com/Shikenso-Analytics/langchain-taiga"

--- a/tests/unit_tests/test_add_attachment_inline_by_ref_tool.py
+++ b/tests/unit_tests/test_add_attachment_inline_by_ref_tool.py
@@ -246,10 +246,12 @@ def test_pre_decode_size_cap_returns_413_without_decode(fake_env, monkeypatch):
 
 def test_size_cap_returns_413_under_lowered_cap(fake_env, monkeypatch):
     """End-to-end size cap behaviour with a small lowered cap so the
-    test doesn't have to allocate 10 MB. With the exact pre-decode
-    formula (accounting for padding), the pre-check fires for any
-    payload strictly larger than the cap; the post-decode branch is
-    defense-in-depth that's effectively unreachable for valid input."""
+    test doesn't have to allocate 10 MB. With this 4-byte cap a
+    5-byte ``b"hello"`` is 1 byte over → the pre-decode upper-bound
+    formula returns ``8 * 3 // 4 = 6`` which is also over (``6 > 4 +
+    3`` is false → falls through; but the post-decode ``5 > 4`` →
+    413). For payloads that are MORE than 3 bytes over, the pre-check
+    fires first. Either branch returns 413 with the same shape."""
     monkeypatch.setattr(taiga_tools, "MAX_INLINE_ATTACHMENT_BYTES", 4)
     entity = fake_env()
     body = b"hello"  # 5 bytes > 4-byte cap

--- a/tests/unit_tests/test_add_attachment_inline_by_ref_tool.py
+++ b/tests/unit_tests/test_add_attachment_inline_by_ref_tool.py
@@ -1,0 +1,575 @@
+"""Unit tests for ``add_attachment_inline_by_ref_tool``.
+
+- ``TestAddAttachmentInlineUnit`` is the LangChain scaffold.
+- Behavioural tests cover happy path, basename sanitization (POSIX +
+  Windows), invalid base64, oversized (pre-decode + post-decode)
+  refusal, empty payload, exactly-at-cap boundary, and entity lookup
+  failure.
+
+No real HTTP is mocked — the tool's only outbound I/O is via
+``Entity.attach`` which we replace with a fake on the
+``python-taiga`` seam.
+"""
+
+import base64
+import json
+
+import pytest
+from langchain_core.tools import BaseTool
+from langchain_tests.unit_tests import ToolsUnitTests
+
+from langchain_taiga.tools import taiga_tools
+from langchain_taiga.tools.taiga_tools import add_attachment_inline_by_ref_tool
+
+
+@pytest.fixture(autouse=True)
+def fake_token(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "FAKE_TOKEN_FOR_TESTS")
+
+
+@pytest.fixture(autouse=True)
+def fake_taiga_url(monkeypatch):
+    monkeypatch.setattr(taiga_tools, "TAIGA_URL", "https://taiga.example.test")
+
+
+# Sample payload for the scaffold's required tool_invoke_params_example.
+_SCAFFOLD_PAYLOAD = base64.b64encode(b"hello").decode("ascii")
+
+
+class TestAddAttachmentInlineUnit(ToolsUnitTests):
+    @property
+    def tool_constructor(self) -> BaseTool:
+        return add_attachment_inline_by_ref_tool
+
+    @property
+    def tool_constructor_params(self) -> dict:
+        return {}
+
+    @property
+    def tool_invoke_params_example(self) -> dict:
+        return {
+            "project_slug": "slug",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "hello.txt",
+            "attachment_content_base64": _SCAFFOLD_PAYLOAD,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Behavioural test infrastructure.
+# ---------------------------------------------------------------------------
+
+
+class _FakeAttachment:
+    """Mimics python-taiga's ``Attachment`` minimally for ``.to_dict()``."""
+
+    def __init__(self, aid, name, size, description, url):
+        self.id = aid
+        self.name = name
+        self.size = size
+        self.description = description
+        self.url = url
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "size": self.size,
+            "description": self.description,
+            "url": self.url,
+        }
+
+
+class _FakeEntity:
+    """Records the (basename, bytes, description) passed to ``attach``."""
+
+    def __init__(self):
+        self.attach_calls = []  # list of (basename, bytes, description)
+        self.attach_should_raise = None
+
+    def attach(self, file_path, description=""):
+        if self.attach_should_raise is not None:
+            raise self.attach_should_raise
+        import os as _os  # local alias to avoid cross-test interference
+
+        basename = _os.path.basename(file_path)
+        with open(file_path, "rb") as f:
+            content = f.read()
+        self.attach_calls.append((basename, content, description))
+        return _FakeAttachment(
+            aid=42,
+            name=basename,
+            size=len(content),
+            description=description,
+            url=f"https://taiga.example.test/media/attachments/{basename}",
+        )
+
+
+class _FakeProject:
+    name = "Shikenso Development"
+
+
+@pytest.fixture
+def fake_env(monkeypatch):
+    """Installs an entity + project in the taiga_tools module-level seams
+    and returns the entity so tests can inspect its ``attach_calls``."""
+
+    def _install(entity_present=True, attach_raises=None):
+        entity = _FakeEntity() if entity_present else None
+        if entity is not None:
+            entity.attach_should_raise = attach_raises
+        project = _FakeProject()
+        monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+        monkeypatch.setattr(
+            taiga_tools, "fetch_entity", lambda proj, norm_type, ref: entity
+        )
+        return entity
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests.
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_uploads_bytes_with_caller_filename(fake_env):
+    entity = fake_env()
+    body = b"# Handover\n\nticket 7398 context\n"
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "handover.md",
+            "attachment_content_base64": base64.b64encode(body).decode("ascii"),
+            "description": "auto-uploaded test",
+        }
+    )
+
+    assert len(entity.attach_calls) == 1
+    basename, content, description = entity.attach_calls[0]
+    assert basename == "handover.md"
+    assert content == body
+    assert description == "auto-uploaded test"
+
+    payload = json.loads(raw)
+    assert payload["added"] is True
+    assert payload["type"] == "issue"
+    assert payload["ref"] == 7398
+    assert (
+        payload["url"]
+        == "https://taiga.example.test/project/shikenso-development/issue/7398"
+    )
+    assert payload["attachments"]["name"] == "handover.md"
+    assert payload["attachments"]["size"] == len(body)
+    # content_type is NOT in the response — Taiga derives it from the
+    # filename extension server-side. Re-list to read what Taiga stored.
+    assert "content_type" not in payload
+    # The url field is stripped from the embedded attachment dict (signed URL hygiene).
+    assert "url" not in payload["attachments"]
+
+
+def test_invalid_base64_returns_400_and_no_upload(fake_env):
+    entity = fake_env()
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "broken.bin",
+            "attachment_content_base64": "this!is@not%valid+base64==",
+        }
+    )
+    assert entity.attach_calls == []
+    payload = json.loads(raw)
+    assert payload["code"] == 400
+    assert "base64" in payload["error"].lower()
+
+
+def test_empty_payload_returns_400(fake_env):
+    entity = fake_env()
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "empty.txt",
+            "attachment_content_base64": "",
+        }
+    )
+    assert entity.attach_calls == []
+    payload = json.loads(raw)
+    assert payload["code"] == 400
+    assert "zero" in payload["error"].lower()
+
+
+def test_pre_decode_size_cap_returns_413_without_decode(fake_env, monkeypatch):
+    entity = fake_env()
+    # 14 MB of "A" → upper-bound estimate 14 * 1024 * 1024 * 3 // 4
+    # = 10.5 MB, well above the 10 MB default cap → pre-check 413.
+    # Use repeated 'A' so we don't actually allocate the real bytes
+    # anywhere — base64 decoding WOULD, but we expect the pre-check
+    # to refuse BEFORE decoding.
+    huge_b64 = "A" * (14 * 1024 * 1024)
+
+    # Sentinel: monkey-patch b64decode to fail loudly if the tool tries
+    # to decode despite the pre-check; if test passes, b64decode was
+    # not called.
+    decode_called = {"called": False}
+
+    real_b64decode = base64.b64decode
+
+    def _spy(*args, **kwargs):
+        decode_called["called"] = True
+        return real_b64decode(*args, **kwargs)
+
+    monkeypatch.setattr(taiga_tools.base64, "b64decode", _spy)
+
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "big.bin",
+            "attachment_content_base64": huge_b64,
+        }
+    )
+
+    assert entity.attach_calls == []
+    assert decode_called["called"] is False
+    payload = json.loads(raw)
+    assert payload["code"] == 413
+    assert payload["max_bytes"] == 10 * 1024 * 1024
+
+
+def test_size_cap_returns_413_under_lowered_cap(fake_env, monkeypatch):
+    """End-to-end size cap behaviour with a small lowered cap so the
+    test doesn't have to allocate 10 MB. With the exact pre-decode
+    formula (accounting for padding), the pre-check fires for any
+    payload strictly larger than the cap; the post-decode branch is
+    defense-in-depth that's effectively unreachable for valid input."""
+    monkeypatch.setattr(taiga_tools, "MAX_INLINE_ATTACHMENT_BYTES", 4)
+    entity = fake_env()
+    body = b"hello"  # 5 bytes > 4-byte cap
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "small.bin",
+            "attachment_content_base64": base64.b64encode(body).decode("ascii"),
+        }
+    )
+    assert entity.attach_calls == []
+    payload = json.loads(raw)
+    assert payload["code"] == 413
+    assert payload["max_bytes"] == 4
+
+
+def test_line_wrapped_base64_is_accepted(fake_env):
+    """GNU ``base64`` wraps encoded output at 76 chars with newlines,
+    and many MIME tools / pasted payloads do the same. The tool must
+    accept these as valid base64 (RFC 4648 §3.3) — stripping ASCII
+    whitespace before validation."""
+    entity = fake_env()
+    body = b"this is some longer text " * 4  # ~100 bytes → wraps into 2 lines
+    b64 = base64.b64encode(body).decode("ascii")
+    # Inject a 76-char wrap + trailing newline (GNU base64 default).
+    wrapped = "\n".join(b64[i : i + 76] for i in range(0, len(b64), 76)) + "\n"
+    assert "\n" in wrapped  # sanity: actually has newlines
+
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "wrapped.txt",
+            "attachment_content_base64": wrapped,
+        }
+    )
+    assert len(entity.attach_calls) == 1
+    _, content, _ = entity.attach_calls[0]
+    assert content == body
+    payload = json.loads(raw)
+    assert payload["added"] is True
+
+
+def test_unaligned_oversized_b64_rejected_before_decode(fake_env, monkeypatch):
+    """Regression for Codex P1 (round 2): if the b64 length is not a
+    multiple of 4 (malformed but huge), the size guard must still
+    fire BEFORE ``b64decode`` allocates ~3/4 of the input. The earlier
+    implementation skipped the pre-check on unaligned length and only
+    delegated to ``b64decode(validate=True)``, which raised AFTER
+    allocating — defeating the RSS protection on a 14 MB+1 payload."""
+    entity = fake_env()
+    # Unaligned (len % 4 == 1), but upper bound still > MAX * 1.5.
+    huge_unaligned_b64 = "A" * (14 * 1024 * 1024 + 1)
+    decode_called = {"called": False}
+    real_b64decode = base64.b64decode
+
+    def _spy(*args, **kwargs):
+        decode_called["called"] = True
+        return real_b64decode(*args, **kwargs)
+
+    monkeypatch.setattr(taiga_tools.base64, "b64decode", _spy)
+
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "big.bin",
+            "attachment_content_base64": huge_unaligned_b64,
+        }
+    )
+    assert entity.attach_calls == []
+    assert decode_called["called"] is False
+    payload = json.loads(raw)
+    assert payload["code"] == 413
+    assert payload["max_bytes"] == 10 * 1024 * 1024
+
+
+def test_whitespace_inflated_oversized_b64_rejected_before_clean(
+    fake_env, monkeypatch
+):
+    """Regression for Codex P1 (round 3): the whitespace-strip step
+    allocates O(input) extra memory. A pathological caller could pad
+    ~1 GB of newlines around a small valid b64 string and the previous
+    single-stage clean+check would OOM before reaching the size guard.
+    The raw-length ceiling MUST refuse such inputs before the clean."""
+    monkeypatch.setattr(taiga_tools, "MAX_INLINE_ATTACHMENT_BYTES", 16)
+    entity = fake_env()
+    # 100 chars of whitespace around a tiny valid payload. With cap=16
+    # bytes, MAX * 3/2 = 24 → raw_upper_bound 75 (= 100 * 3 // 4) > 24
+    # → rejected at stage 1, BEFORE the whitespace-clean materialization.
+    inflated = " " * 50 + base64.b64encode(b"hi").decode("ascii") + "\n" * 50
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "padded.bin",
+            "attachment_content_base64": inflated,
+        }
+    )
+    assert entity.attach_calls == []
+    payload = json.loads(raw)
+    assert payload["code"] == 413
+    # The raw-stage error message includes "raw upper-bound".
+    assert "raw upper-bound" in payload["error"]
+
+
+def test_interleaved_whitespace_does_not_materialize_substrings(fake_env, monkeypatch):
+    """Regression for Codex P1 (round 4): a payload that interleaves
+    whitespace between every base64 character (``"A\\nA\\nA..."``)
+    passes the stage-1 raw ceiling at default cap settings, but used
+    to be cleaned with ``str.split()`` which materializes one
+    short-string Python object per ``A`` (~50 bytes header overhead
+    each). A 100K-char interleaved input would balloon to ~5 MB of
+    substring objects even though the cleaned form is 50 KB.
+
+    Switching to ``str.translate`` allocates exactly one new string of
+    the cleaned size. This test verifies the small-input behaviour
+    end-to-end; the memory-amplification fix is covered by the
+    documented choice in the implementation comment."""
+    entity = fake_env()
+    body = b"interleaved-test"
+    b64 = base64.b64encode(body).decode("ascii")
+    # Interleave a newline between every char.
+    interleaved = "\n".join(b64)
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "inter.bin",
+            "attachment_content_base64": interleaved,
+        }
+    )
+    assert len(entity.attach_calls) == 1
+    _, content, _ = entity.attach_calls[0]
+    assert content == body
+
+
+def test_exactly_at_cap_is_accepted(fake_env, monkeypatch):
+    """Regression for Codex P2: with the old ``len(b64) * 3 // 4``
+    estimate, a 5-byte payload (b64 = "aGVsbG8=", 8 chars) hitting a
+    5-byte cap would be rejected because (8 * 3 // 4) == 6 > 5.
+
+    The corrected formula accounts for "=" padding: (8 // 4) * 3 - 1
+    = 5, which equals the cap and is therefore accepted (only ``>``
+    triggers 413, matching the post-decode check)."""
+    monkeypatch.setattr(taiga_tools, "MAX_INLINE_ATTACHMENT_BYTES", 5)
+    entity = fake_env()
+    body = b"hello"  # exactly 5 bytes
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "exact.bin",
+            "attachment_content_base64": base64.b64encode(body).decode("ascii"),
+        }
+    )
+    assert len(entity.attach_calls) == 1
+    payload = json.loads(raw)
+    assert payload["added"] is True
+    assert payload["attachments"]["size"] == 5
+
+
+def test_windows_path_filename_stripped_on_linux_host(fake_env):
+    """Regression for Codex P3: a Windows client passing a Windows-
+    style path must have its drive + backslash separators stripped,
+    not preserved (the prior ``os.path.basename`` on a Linux MCP pod
+    treated ``\\`` as part of the filename).
+    """
+    entity = fake_env()
+    body = b"y"
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "C:\\Users\\wahed\\Documents\\handover.md",
+            "attachment_content_base64": base64.b64encode(body).decode("ascii"),
+        }
+    )
+    assert len(entity.attach_calls) == 1
+    basename, _, _ = entity.attach_calls[0]
+    assert basename == "handover.md"
+    payload = json.loads(raw)
+    assert payload["attachments"]["name"] == "handover.md"
+
+
+def test_path_traversal_filename_stripped_to_basename(fake_env):
+    entity = fake_env()
+    body = b"x"
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "../../../etc/passwd",
+            "attachment_content_base64": base64.b64encode(body).decode("ascii"),
+        }
+    )
+    assert len(entity.attach_calls) == 1
+    basename, _, _ = entity.attach_calls[0]
+    assert basename == "passwd"  # path components stripped
+    payload = json.loads(raw)
+    assert payload["attachments"]["name"] == "passwd"
+
+
+def test_empty_filename_returns_400(fake_env):
+    entity = fake_env()
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "",
+            "attachment_content_base64": base64.b64encode(b"x").decode("ascii"),
+        }
+    )
+    assert entity.attach_calls == []
+    payload = json.loads(raw)
+    assert payload["code"] == 400
+
+
+def test_dot_dot_filename_returns_400(fake_env):
+    """Regression for Codex P3 (round 2): ``PureWindowsPath('..').name``
+    returns ``'..'`` (and same for ``'foo/..'``), which previously
+    slipped through the empty-name check and then crashed
+    ``open(tmpdir/'..', 'wb')`` with ``IsADirectoryError`` → bubbled
+    as a misleading 500. Treat dot-segments as user input errors with
+    a precise 400. Note that ``'.'``-only segments inside a path
+    (e.g. ``'foo/.'``) are normalized away by pathlib and resolve to
+    a valid basename, so they are accepted."""
+    entity = fake_env()
+    for bad in ("..", ".", "foo/.."):
+        raw = add_attachment_inline_by_ref_tool.invoke(
+            {
+                "project_slug": "shikenso-development",
+                "entity_ref": 7398,
+                "entity_type": "issue",
+                "attachment_filename": bad,
+                "attachment_content_base64": base64.b64encode(b"x").decode("ascii"),
+            }
+        )
+        payload = json.loads(raw)
+        assert payload["code"] == 400, f"input {bad!r} should 400, got {payload}"
+    assert entity.attach_calls == []
+
+
+def test_pure_separator_filename_returns_400(fake_env):
+    """A filename made entirely of separators (e.g. ``/``) basenames to
+    '' and must be rejected. ``PureWindowsPath`` normalizes
+    ``some/dir/`` to ``some/dir`` → ``dir`` (user-friendly trailing-
+    slash fix), so the all-separator case is the remaining null
+    basename to test."""
+    entity = fake_env()
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "/",
+            "attachment_content_base64": base64.b64encode(b"x").decode("ascii"),
+        }
+    )
+    assert entity.attach_calls == []
+    payload = json.loads(raw)
+    assert payload["code"] == 400
+
+
+def test_invalid_entity_type_returns_400(fake_env):
+    entity = fake_env()
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "story",  # not in ENTITY_TYPE_MAPPING
+            "attachment_filename": "foo.txt",
+            "attachment_content_base64": base64.b64encode(b"x").decode("ascii"),
+        }
+    )
+    assert entity.attach_calls == []
+    payload = json.loads(raw)
+    assert payload["code"] == 400
+    assert "story" in payload["error"]
+
+
+def test_entity_not_found_returns_404(fake_env):
+    fake_env(entity_present=False)
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 9999,
+            "entity_type": "issue",
+            "attachment_filename": "foo.txt",
+            "attachment_content_base64": base64.b64encode(b"x").decode("ascii"),
+        }
+    )
+    payload = json.loads(raw)
+    assert payload["code"] == 404
+    assert "9999" in payload["error"]
+
+
+def test_taiga_upload_failure_returns_500(fake_env):
+    entity = fake_env(attach_raises=RuntimeError("taiga 503"))
+    raw = add_attachment_inline_by_ref_tool.invoke(
+        {
+            "project_slug": "shikenso-development",
+            "entity_ref": 7398,
+            "entity_type": "issue",
+            "attachment_filename": "foo.txt",
+            "attachment_content_base64": base64.b64encode(b"x").decode("ascii"),
+        }
+    )
+    payload = json.loads(raw)
+    assert payload["code"] == 500
+    assert "taiga 503" in payload["error"]
+    # entity.attach raised before the recorder appended.
+    assert entity.attach_calls == []

--- a/tests/unit_tests/test_mcp.py
+++ b/tests/unit_tests/test_mcp.py
@@ -16,6 +16,7 @@ EXPECTED_TOOL_NAMES = frozenset(
         "update_entity_by_ref_tool",
         "add_comment_by_ref_tool",
         "add_attachment_by_ref_tool",
+        "add_attachment_inline_by_ref_tool",
         "list_attachments_by_ref_tool",
         "get_attachment_by_ref_tool",
         "promote_issue_to_userstory_tool",


### PR DESCRIPTION
## Summary

Adds **`add_attachment_inline_by_ref_tool`** — the symmetric counterpart to `get_attachment_by_ref_tool` (PR #18). MCP clients (Claude Code, claude.ai) can now upload a local file to a Taiga entity via inline base64 in one tool call, without exposing it through a public URL, ngrok tunnel, or paste service.

## Why

Before this PR, the only attachment-upload path through the MCP was `add_attachment_by_ref_tool`, which fetches a **public URL** server-side. Practical workarounds for "attach `/tmp/foo.md` to ticket 7398":

1. Public host + URL → leaks internal data
2. ngrok / local HTTP → overhead, external dep
3. Direct `python-taiga` + `.env` creds → bypasses MCP entirely (the workaround the customer-feedback agent ended up using on ticket #7332)

The download side already supports inline-base64 transport (`get_attachment_by_ref_tool` in 2.6.0). This PR closes the symmetric gap on the upload side.

## What changed

### New tool

```python
add_attachment_inline_by_ref_tool(
    project_slug: str,
    entity_ref: int,
    entity_type: str,
    attachment_filename: str,
    attachment_content_base64: str,
    description: str = "",
) -> str
```

- Tempdir-scoped path so `python-taiga`'s multipart upload uses the caller's filename verbatim (`os.path.basename(file_path)`), not the `tmpXXXX.<ext>` leak of the URL-based tool.
- Taiga sniffs `content_type` server-side from the filename extension; no separate MIME parameter (the python-taiga API doesn't expose one, and reporting a content_type that doesn't survive a round-trip would be misleading).
- Reuses the existing `TAIGA_MAX_INLINE_ATTACHMENT_BYTES` cap (default 10 MB).

### Validation hardening (post Codex review iteration)

| Concern | Implementation |
|---|---|
| Path-traversal | `PureWindowsPath(...).name` (handles both POSIX `/` and Windows `\\` separators on the Linux MCP pod) |
| Dot-segments | Explicit reject of `..`, `.`, `foo/..` → 400 (would otherwise crash `open(tmpdir/'..', 'wb')`) |
| RSS DoS (1 GB inputs) | Stage-1 raw-length ceiling (`raw_upper > MAX * 3/2`) before any whitespace processing |
| RSS DoS (`"A\nA\nA..."` inputs) | `str.translate` for whitespace strip (single allocation; not `str.split() + "".join()` which materializes substring-per-char) |
| Off-by-one at cap | Pre-decode upper-bound check uses `> MAX + 3` slack to absorb base64 padding + alignment overshoot; post-decode `>` check is precise |
| Line-wrapped GNU base64 | ASCII whitespace stripped before validation (RFC 4648 §3.3 compliant) |
| Empty / invalid b64 / empty filename | Discrete 400s with diagnostic messages |
| Blocking I/O on async loop | Added to `_TOOLS_NEEDING_ASYNC_OFFLOAD` (entity.attach is blocking HTTP) |

### Registration

- Exported via `langchain_taiga.__init__`, `TaigaToolkit.get_tools()`, and `_register_mcp_tools` (20 → 21 tools)
- `test_mcp.py::EXPECTED_TOOL_NAMES` updated
- Version bump `2.6.0 → 2.7.0`, README + description updated

### Tests

17 behavioural tests covering: happy path, line-wrapped GNU-base64, interleaved-whitespace, invalid base64, empty payload, pre-decode size cap, unaligned-length oversize, whitespace-inflated oversize, exactly-at-cap acceptance, basename sanitization (POSIX traversal + Windows path), dot-segment rejection, pure-separator rejection, invalid entity_type, entity not found, python-taiga upload failure → 500.

## Validation

- `python -m pytest --disable-socket --allow-unix-socket tests/unit_tests/` → **270 passed, 1 skipped**
- Codex pre-push review (gpt-5.4 xhigh, normal mode): 6 rounds, 8 findings addressed → clean

## Follow-up (NOT in this PR)

The existing `add_attachment_by_ref_tool` (URL-based) leaks `/tmp/tmpXXXX.<ext>` as the Taiga attachment display name (the multipart `name` is `os.path.basename(temp_file_path)`). The new tool's tempdir-with-caller-filename pattern fixes this for inline uploads. A small separate PR could backport the same pattern to the URL tool by parsing the filename from the URL path.

Codex-Review: gpt-5.4 xhigh normal, 8 findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)