### PR TITLE
Trim pyproject description below PyPI 512-char summary limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "langchain-taiga"
 version = "2.7.0"
-description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5 adds OAuth refresh-token rotation with reuse-detection for stable long-lived connections. v2.6 adds attachment list/get tools for reading existing ticket attachments. v2.7 adds inline-base64 file upload so MCP clients can attach local files without exposing them via a public URL."
+description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5+ adds OAuth refresh-token rotation with reuse-detection and attachment read/write tools (list, get, and inline-base64 upload of local files)."
 authors = []
 readme = "README.md"
 repository = "https://github.com/Shikenso-Analytics/langchain-taiga"


### PR DESCRIPTION
## Summary

Hotfix for the 2.7.0 publish failure. PyPI rejected the wheel with HTTP 400:

```
'summary' field must be 512 characters or less.
See https://packaging.python.org/specifications/core-metadata
```

The description had grown to **540 chars** because I appended a per-version-bump sentence for v2.5, v2.6, and v2.7. PyPI's `summary` (Core Metadata `Summary` field) maps to `pyproject.toml`'s `description`.

## What changed

Collapsed the per-version enumeration into a single v2.5+ sentence:

- **Before** (540 chars): `… v2.5 adds OAuth refresh-token rotation … v2.6 adds attachment list/get tools … v2.7 adds inline-base64 file upload …`
- **After** (401 chars): `… v2.5+ adds OAuth refresh-token rotation with reuse-detection and attachment read/write tools (list, get, and inline-base64 upload of local files).`

No code change. Only the `description` string in `pyproject.toml` moves.

## Validation

```
$ python -c 'import tomllib; print(len(tomllib.load(open("pyproject.toml","rb"))["tool"]["poetry"]["description"]))'
401
```

Below the 512 hard limit. Once merged, the next CI publish run will rebuild the wheel and PyPI will accept the upload (version 2.7.0 is reserved but never landed because the publish step errored).

## Codex review

Skipped per `pr-creation-ci/SKILL.md` Section 4a: "Pure version/dependency bumps without code changes". This is a metadata-string-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)