### PR TITLE
Surface dropdown choices in list_custom_attributes_tool (2.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 21 tools:
 - **`list_attachments_by_ref_tool`**: List all attachments on an entity with fresh signed download URLs. URL tokens from the Taiga UI/webhook diff expire after ~6 min; this tool re-mints them on every call.
 - **`get_attachment_by_ref_tool`**: Fetch a specific attachment by ID and return its content base64-encoded inline. Refuses files larger than `TAIGA_MAX_INLINE_ATTACHMENT_BYTES` (default 10 MB) — for larger files use `list_attachments_by_ref_tool` and `curl` the `download_url` out-of-band.
 - **`promote_issue_to_userstory_tool`**: Promotes an issue to a user story, preserving comments and history.
-- **`list_custom_attributes_tool`**: Lists custom-attribute *definitions* for a project + entity type.
+- **`list_custom_attributes_tool`**: Lists custom-attribute definitions for a project + entity type, including dropdown `choices` (parsed) and the raw `extra` field — so an agent can discover the valid options for a dropdown attribute before writing via `set_custom_attributes_tool`.
 - **`set_custom_attributes_tool`**: Sets custom-attribute values on a user story, task or issue.
 - **`get_custom_attributes_tool`**: Reads custom-attribute values from a user story, task or issue.
 - **`sort_kanban_by_rice_tool`**: Re-orders Kanban swimlanes using a RICE-style score. Closed status columns (Done, Cancelled, …) are skipped — re-ranking already-completed work has no value. Each entry in `columns_updated` carries `status_name` alongside `status_id` so consumers don't need to round-trip through Taiga to translate the id.

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2453,9 +2453,10 @@ def list_custom_attributes_tool(
         entity_type: 'userstory', 'task', 'issue', or 'epic'
 
     Returns:
-        JSON list of custom-attribute definitions. Each entry has id,
-        name, description, type, order, extra, choices. For
-        type='dropdown', ``choices`` is the parsed list of valid
+        JSON envelope ``{project, entity_type, custom_attributes}``
+        where ``custom_attributes`` is the list of definitions. Each
+        entry has id, name, description, type, order, extra, choices.
+        For type='dropdown', ``choices`` is the parsed list of valid
         option strings — use one of them as the value to
         ``set_custom_attributes_tool``. ``extra`` is the raw
         newline-delimited string returned by the Taiga API. For

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2453,7 +2453,14 @@ def list_custom_attributes_tool(
         entity_type: 'userstory', 'task', 'issue', or 'epic'
 
     Returns:
-        JSON list of custom attributes with id, name, description, and type
+        JSON list of custom-attribute definitions. Each entry has id,
+        name, description, type, order, extra, choices. For
+        type='dropdown', ``choices`` is the parsed list of valid
+        option strings — use one of them as the value to
+        ``set_custom_attributes_tool``. ``extra`` is the raw
+        newline-delimited string returned by the Taiga API. For
+        non-dropdown types, ``choices`` is an empty list and
+        ``extra`` is null or empty.
 
     Examples:
         list_custom_attributes_tool("wahed", "userstory")
@@ -2480,13 +2487,29 @@ def list_custom_attributes_tool(
 
         result = []
         for attr in attrs:
+            attr_type = getattr(attr, "type", "text")
+            extra_raw = getattr(attr, "extra", None)
+            if attr_type == "dropdown" and isinstance(extra_raw, str):
+                # Taiga stores dropdown options as a newline-delimited
+                # string. Normalize CRLF, trim per-line whitespace, drop
+                # empties so a trailing newline (common in the admin UI)
+                # doesn't produce a phantom "" choice.
+                choices = [
+                    line.strip()
+                    for line in extra_raw.replace("\r\n", "\n").split("\n")
+                    if line.strip()
+                ]
+            else:
+                choices = []
             result.append(
                 {
                     "id": attr.id,
                     "name": attr.name,
                     "description": getattr(attr, "description", ""),
-                    "type": getattr(attr, "type", "text"),
+                    "type": attr_type,
                     "order": getattr(attr, "order", 0),
+                    "extra": extra_raw,
+                    "choices": choices,
                 }
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.7.0"
-description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5+ adds OAuth refresh-token rotation with reuse-detection and attachment read/write tools (list, get, and inline-base64 upload of local files)."
+version = "2.8.0"
+description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5+ adds OAuth refresh-token rotation, attachment read/write tools (list/get/inline-base64 upload), and dropdown-choice discovery on list_custom_attributes_tool."
 authors = []
 readme = "README.md"
 repository = "https://github.com/Shikenso-Analytics/langchain-taiga"

--- a/tests/unit_tests/test_list_custom_attributes_tool.py
+++ b/tests/unit_tests/test_list_custom_attributes_tool.py
@@ -1,0 +1,222 @@
+"""Unit tests for ``list_custom_attributes_tool``.
+
+- ``TestListCustomAttributesUnit`` is the LangChain scaffold.
+- Behavioural tests cover the new ``extra`` + ``choices`` fields added
+  in 2.8.0: dropdown choice parsing (CRLF normalization, whitespace
+  trimming, empty-line drop), non-dropdown null handling, empty
+  dropdown configuration, and entity-type dispatch.
+"""
+
+import json
+
+import pytest
+from langchain_core.tools import BaseTool
+from langchain_tests.unit_tests import ToolsUnitTests
+
+from langchain_taiga.tools import taiga_tools
+from langchain_taiga.tools.taiga_tools import list_custom_attributes_tool
+
+
+@pytest.fixture(autouse=True)
+def fake_token(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "FAKE_TOKEN_FOR_TESTS")
+
+
+@pytest.fixture(autouse=True)
+def fake_taiga_url(monkeypatch):
+    monkeypatch.setattr(taiga_tools, "TAIGA_URL", "https://taiga.example.test")
+
+
+class TestListCustomAttributesUnit(ToolsUnitTests):
+    @property
+    def tool_constructor(self) -> BaseTool:
+        return list_custom_attributes_tool
+
+    @property
+    def tool_constructor_params(self) -> dict:
+        return {}
+
+    @property
+    def tool_invoke_params_example(self) -> dict:
+        return {"project_slug": "slug", "entity_type": "userstory"}
+
+
+# ---------------------------------------------------------------------------
+# Behavioural test infrastructure.
+# ---------------------------------------------------------------------------
+
+
+class _FakeAttr:
+    """Mimics python-taiga's CustomAttribute model for the read path.
+
+    ``extra`` is hydrated at runtime by ``InstanceResource.__init__``
+    via ``setattr`` even though it's not in ``allowed_params`` — see
+    the implementation comment in ``list_custom_attributes_tool``.
+    """
+
+    def __init__(self, aid, name, attr_type, extra=None, description="", order=0):
+        self.id = aid
+        self.name = name
+        self.type = attr_type
+        self.extra = extra
+        self.description = description
+        self.order = order
+
+
+class _FakeProject:
+    """Returns the same list for whichever entity-type call we set."""
+
+    name = "Shikenso Development"
+
+    def __init__(self, attrs_by_type):
+        # attrs_by_type: dict like {"userstory": [...], "task": [...]}.
+        # Calls touching a key NOT in the dict get [] — used by the
+        # dispatch test to confirm only the requested method ran.
+        self._attrs_by_type = attrs_by_type
+
+    def list_user_story_attributes(self):
+        return list(self._attrs_by_type.get("userstory", []))
+
+    def list_task_attributes(self):
+        return list(self._attrs_by_type.get("task", []))
+
+    def list_issue_attributes(self):
+        return list(self._attrs_by_type.get("issue", []))
+
+    def list_epic_attributes(self):
+        return list(self._attrs_by_type.get("epic", []))
+
+
+@pytest.fixture
+def fake_env(monkeypatch):
+    """Install a project whose per-entity-type attribute lists are
+    keyed by the entity name. Returns the project so tests can inspect
+    call records if needed."""
+
+    def _install(attrs_by_type=None):
+        project = _FakeProject(attrs_by_type or {})
+        monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+        return project
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests.
+# ---------------------------------------------------------------------------
+
+
+def test_dropdown_attribute_exposes_parsed_choices_and_raw_extra(fake_env):
+    fake_env(
+        {
+            "userstory": [
+                _FakeAttr(
+                    18,
+                    "Task difficulty",
+                    "dropdown",
+                    extra="easy\nmedium\nhard",
+                    description="How long this will take",
+                )
+            ]
+        }
+    )
+    raw = list_custom_attributes_tool.invoke(
+        {"project_slug": "shikenso-development", "entity_type": "userstory"}
+    )
+    payload = json.loads(raw)
+    attrs = payload["custom_attributes"]
+    assert len(attrs) == 1
+    entry = attrs[0]
+    assert entry["id"] == 18
+    assert entry["name"] == "Task difficulty"
+    assert entry["type"] == "dropdown"
+    assert entry["extra"] == "easy\nmedium\nhard"
+    assert entry["choices"] == ["easy", "medium", "hard"]
+
+
+def test_crlf_normalized_and_trailing_newline_stripped(fake_env):
+    fake_env(
+        {"userstory": [_FakeAttr(1, "X", "dropdown", extra="a\r\nb\n")]}
+    )
+    raw = list_custom_attributes_tool.invoke(
+        {"project_slug": "slug", "entity_type": "userstory"}
+    )
+    entry = json.loads(raw)["custom_attributes"][0]
+    # No phantom empty string from the trailing newline; CRLF collapsed.
+    assert entry["choices"] == ["a", "b"]
+
+
+def test_per_line_whitespace_stripped_empty_lines_dropped(fake_env):
+    fake_env(
+        {
+            "userstory": [
+                _FakeAttr(
+                    1,
+                    "X",
+                    "dropdown",
+                    extra="  easy (1 day)  \n\nmedium (2-3 days)\n",
+                )
+            ]
+        }
+    )
+    raw = list_custom_attributes_tool.invoke(
+        {"project_slug": "slug", "entity_type": "userstory"}
+    )
+    entry = json.loads(raw)["custom_attributes"][0]
+    assert entry["choices"] == ["easy (1 day)", "medium (2-3 days)"]
+
+
+def test_non_dropdown_type_has_empty_choices_and_null_extra(fake_env):
+    fake_env(
+        {"userstory": [_FakeAttr(2, "Notes", "multiline", extra=None)]}
+    )
+    raw = list_custom_attributes_tool.invoke(
+        {"project_slug": "slug", "entity_type": "userstory"}
+    )
+    entry = json.loads(raw)["custom_attributes"][0]
+    assert entry["type"] == "multiline"
+    assert entry["extra"] is None
+    assert entry["choices"] == []
+
+
+def test_empty_string_extra_on_dropdown_yields_empty_choices(fake_env):
+    """User has the dropdown type set but hasn't configured any
+    options yet — extra is the empty string, NOT null."""
+    fake_env(
+        {"userstory": [_FakeAttr(3, "Priority", "dropdown", extra="")]}
+    )
+    raw = list_custom_attributes_tool.invoke(
+        {"project_slug": "slug", "entity_type": "userstory"}
+    )
+    entry = json.loads(raw)["custom_attributes"][0]
+    assert entry["type"] == "dropdown"
+    assert entry["extra"] == ""
+    assert entry["choices"] == []
+
+
+def test_entity_type_dispatch_routes_to_task_attributes(fake_env):
+    """Invoking with entity_type='task' must hit
+    ``list_task_attributes()``, NOT ``list_user_story_attributes()``."""
+    fake_env(
+        {
+            "userstory": [
+                _FakeAttr(99, "Should-not-appear", "dropdown", extra="us-only")
+            ],
+            "task": [
+                _FakeAttr(
+                    10,
+                    "Task-only attr",
+                    "dropdown",
+                    extra="t1\nt2",
+                )
+            ],
+        }
+    )
+    raw = list_custom_attributes_tool.invoke(
+        {"project_slug": "slug", "entity_type": "task"}
+    )
+    payload = json.loads(raw)
+    attrs = payload["custom_attributes"]
+    assert len(attrs) == 1
+    assert attrs[0]["id"] == 10
+    assert attrs[0]["choices"] == ["t1", "t2"]


### PR DESCRIPTION
## Summary

`list_custom_attributes_tool` now returns the `extra` field (raw, passthrough from Taiga's API) and a pre-parsed `choices` list per attribute — so an agent setting a dropdown-type custom field can discover the valid option strings without bypassing the MCP.

## Why

A downstream agent ([context: filling custom fields on issue #7332](https://taiga.shikenso.org)) hit a workflow gap: the existing tool returned only `id, name, description, type, order`, with no way to discover the valid choices for a `type: "dropdown"` attribute. The agent's workaround was to:

1. Pull project credentials from `.env`
2. Instantiate `TaigaAPI` directly via python-taiga
3. Read `attr.extra` off the model

…which defeats the MCP's multi-tenant boundary. The remote MCP at `taiga.shikenso.org/mcp` doesn't have client-side creds; only the dev box could pull this off. Other clients (claude.ai Custom Connectors, VSCode Web) have no escape hatch and would have been stuck guessing values.

## What changes in the response shape

### Before (5 fields per attribute)
```json
{
  "id": 18,
  "name": "Task difficulty",
  "description": "How long this will take",
  "type": "dropdown",
  "order": 0
}
```

### After (7 fields per attribute)
```json
{
  "id": 18,
  "name": "Task difficulty",
  "description": "How long this will take",
  "type": "dropdown",
  "order": 0,
  "extra": "easy (1 day)\nmedium (2-3 days)\nhard (3+ days)",
  "choices": ["easy (1 day)", "medium (2-3 days)", "hard (3+ days)"]
}
```

For non-dropdown types (`text`, `multiline`, `richtext`, `date`, `url`, `number`, `checkbox`): `extra` is `null` or `""`, `choices` is `[]`.

**Backward compatibility:** Additive only. Existing consumers reading `id/name/description/type/order` are unaffected.

## Why both `extra` (raw) and `choices` (parsed)

- `choices: list[str]` is the LLM-friendly answer to *"what can I pass to `set_custom_attributes_tool`?"*. Pre-parsed, no string-splitting on the agent's side.
- `extra` is the raw Taiga-API value, kept as a faithful passthrough for any consumer that needs the original wire format, and as a future-proofing escape hatch if Taiga ever adds new `extra`-bearing types we haven't taught the parser about.

The parsing normalizes CRLF, trims per-line whitespace, and drops empty lines so a trailing newline from the Taiga admin UI doesn't produce a phantom `""` choice.

## Why no python-taiga changes were needed

`InstanceResource.__init__` (in `taiga/base.py:21-26`) hydrates every API-response key via `setattr`, including `extra`. The library's `CustomAttribute.allowed_params` omits `extra` (gating writes only), but `attr.extra` is fully populated for reads via dynamic attribute access — `getattr(attr, "extra", None)` is all that's needed.

## Validation

| Check | Status |
|---|---|
| Full unit test suite | **282 passed, 1 skipped** (was 276+1 before; +6 new behavioural tests) |
| Codex pre-push review (gpt-5.4 xhigh normal) | **clean** — no findings |
| Description length (PyPI 512-char `summary` limit) | 418 chars |
| Tool surface | unchanged — 21 tools, response shape additive only |

## Files changed

| File | Change |
|---|---|
| `langchain_taiga/tools/taiga_tools.py` | +27 / -5 — new `extra`/`choices` build + docstring `Returns:` update |
| `tests/unit_tests/test_list_custom_attributes_tool.py` | **NEW** — scaffold + 6 behavioural tests |
| `pyproject.toml` | version `2.7.0` → `2.8.0`, description appended |
| `README.md` | 1 bullet expanded to mention dropdown `choices` discovery |

## Follow-up (NOT in this PR)

- **`__init__.py` gap**: 5 of 21 tools (the 3 custom-attribute tools + `sort_kanban_by_rice_tool` + `promote_issue_to_userstory_tool`) are not re-exported at the package root. Pre-existing, unrelated to this PR.
- **`set_custom_attributes_tool` choice validation**: now that the listing tool exposes valid choices, the setter could validate dropdown values upfront and return a precise 400 instead of bubbling Taiga's generic rejection. Separate, larger scope.

Codex-Review: gpt-5.4 xhigh normal, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)