### PR TITLE
Make Confidence optional in sort_kanban_by_rice_tool (2.10.0)

### DIFF
--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -2971,6 +2971,10 @@ def sort_kanban_by_rice_tool(
     """
     Sort user stories in the Kanban board by their RICE score.
     RICE = (Reach × Impact × Confidence) / Effort
+    (Confidence is optional — defaults to 1 when the project has no
+    Confidence custom attribute; Reach and Impact are required.
+    Attribute discovery is cached ~5 min, so a newly-added Confidence
+    attribute may take up to that long to affect scoring.)
     Final Priority = RICE × Epic Multiplicator × Completion Bonus × Urgency Multiplier
 
     Closed status columns (Done, Cancelled, …) are skipped — re-ranking
@@ -3060,12 +3064,27 @@ async def _sort_kanban_async_impl(project_slug: str, descending: bool) -> str:
         blocked_by_attr_id = attr_defs["blocked_by_attr_id"]
         multiplicator_attr_id = attr_defs["multiplicator_attr_id"]
 
-        if len(rice_attrs) < 3:
+        # Reach + Impact are mandatory. Confidence is OPTIONAL and defaults
+        # to 1 in the RICE product when the board has no Confidence custom
+        # attribute (the shikenso-development board dropped to Reach+Impact
+        # only). Pre-2.10.0 this gate required all three and 400'd boards
+        # without Confidence.
+        #
+        # Accepted limitation: rice_attrs comes from the 5-min-cached
+        # _discover_sort_attr_ids. A board sorted while it has no Confidence
+        # attribute, then given one, keeps scoring confidence=1 until the
+        # cache TTL expires (~5 min). This is a bounded transient — the same
+        # staleness already applies to renaming Reach/Impact — and boards
+        # that intentionally omit Confidence score 1 correctly and forever.
+        required_attrs = {"reach", "impact"}
+        missing_required = sorted(required_attrs - set(rice_attrs))
+        if missing_required:
             return json.dumps(
                 {
                     "error": "RICE custom attributes not fully configured",
                     "found": list(rice_attrs.keys()),
-                    "required": ["reach", "impact", "confidence"],
+                    "required": sorted(required_attrs),
+                    "missing": missing_required,
                     "code": 400,
                 },
                 indent=2,
@@ -3182,7 +3201,11 @@ async def _sort_kanban_async_impl(project_slug: str, descending: bool) -> str:
 
             reach = attr_values.get(rice_attrs["reach"], 1) or 1
             impact = attr_values.get(rice_attrs["impact"], 1) or 1
-            confidence = attr_values.get(rice_attrs["confidence"], 1) or 1
+            # Confidence is optional (see the gate above). A board without a
+            # Confidence attribute scores confidence as 1 instead of raising
+            # KeyError on rice_attrs["confidence"].
+            conf_id = rice_attrs.get("confidence")
+            confidence = (attr_values.get(conf_id, 1) if conf_id else 1) or 1
 
             effort = getattr(us, "total_points", None) or 0
 

--- a/langchain_taiga/tools/taiga_tools.py
+++ b/langchain_taiga/tools/taiga_tools.py
@@ -3082,7 +3082,7 @@ async def _sort_kanban_async_impl(project_slug: str, descending: bool) -> str:
             return json.dumps(
                 {
                     "error": "RICE custom attributes not fully configured",
-                    "found": list(rice_attrs.keys()),
+                    "found": sorted(rice_attrs.keys()),
                     "required": sorted(required_attrs),
                     "missing": missing_required,
                     "code": 400,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-taiga"
-version = "2.9.0"
+version = "2.10.0"
 description = "Python toolkit that lets your LangChain agents automate Taiga: create, search, edit & comment on user stories, tasks and issues via the official REST API. v2 introduces the multi-tenant remote MCP mode (HTTP+OAuth) alongside the existing stdio transport. v2.5+ adds OAuth refresh-token rotation, attachment tools (add/list/get), and dropdown-choice discovery on list_custom_attributes_tool."
 authors = []
 readme = "README.md"

--- a/tests/unit_tests/test_sort_kanban_by_rice_tool.py
+++ b/tests/unit_tests/test_sort_kanban_by_rice_tool.py
@@ -917,3 +917,65 @@ def test_attr_def_cache_skips_second_discovery(
     # Same project_slug, within 5-min TTL → discovery skipped.
     assert project.list_user_story_attributes_calls == first_us_attr_calls
     assert project.list_epic_attributes_calls == first_epic_attr_calls
+
+
+def _reach_impact_only_attrs():
+    """Board exposing ONLY Reach + Impact — the shikenso-development state
+    after Business Priorisation / Story Points Left were removed and no
+    Confidence custom attribute was ever added."""
+    return [
+        _FakeAttr(1, "Reach"),
+        _FakeAttr(2, "Impact"),
+    ]
+
+
+def test_sorts_with_confidence_absent_defaulting_to_one(
+    monkeypatch, patched_http, respx_mock
+):
+    """A board with only Reach + Impact (no Confidence attribute) MUST still
+    sort: confidence defaults to 1 in the RICE product. Before this change
+    the tool returned 400 'RICE custom attributes not fully configured'
+    because the gate required all of reach/impact/confidence."""
+    story = _FakeUS(
+        ref=42,
+        points={},
+        total_points=2.0,
+        attr_values={"1": 4, "2": 3},  # reach=4, impact=3, NO confidence key
+    )
+    project = _FakeProject(
+        stories=[story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=_reach_impact_only_attrs(),
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(respx_mock, [story])
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+    assert payload.get("sorted") is True
+    order = payload["columns_updated"][0]["order"]
+    # RICE = (reach 4 × impact 3 × confidence 1) / effort 2 = 6.0
+    assert order[0]["rice"] == 6.0
+
+
+def test_missing_reach_or_impact_still_returns_400(
+    monkeypatch, patched_http, respx_mock
+):
+    """Reach and Impact stay mandatory: a board missing either still returns
+    the 'not fully configured' 400 and names what's missing. Only Confidence
+    became optional."""
+    story = _FakeUS(ref=7, points={}, total_points=2.0, attr_values={"1": 5})
+    project = _FakeProject(
+        stories=[story],
+        roles=[_FakeAttr(19, "Developer")],
+        points=_baseline_points(),
+        us_attrs=[_FakeAttr(1, "Reach")],  # Impact missing
+    )
+    monkeypatch.setattr(taiga_tools, "get_project", lambda slug: project)
+    _register_us_attr_routes(respx_mock, [story])
+
+    raw = sort_kanban_by_rice_tool.invoke({"project_slug": "wahed"})
+    payload = json.loads(raw)
+    assert payload["code"] == 400
+    assert "impact" in payload["missing"]


### PR DESCRIPTION
## Summary

Makes the `Confidence` RICE custom attribute **optional** in `sort_kanban_by_rice_tool`. Reach + Impact stay mandatory; Confidence defaults to `1` in the RICE product when a board has no Confidence attribute. This unblocks the RICE sort on `shikenso-development`, whose user-story custom attributes were reduced to **Reach + Impact only** — which previously made the tool return a 400 `"RICE custom attributes not fully configured"`.

## What changed
- **Gate relaxed** (`langchain_taiga/tools/taiga_tools.py`): require `{reach, impact}` instead of all three. The 400 payload now includes a `missing` key listing which required attrs are absent.
- **Confidence read guarded**: `conf_id = rice_attrs.get("confidence"); confidence = (attr_values.get(conf_id, 1) if conf_id else 1) or 1` — no `KeyError` when Confidence is undefined; defaults to 1.
- **Docstring + comment** document the optionality and the bounded ~5-min attribute-discovery cache window (see Notes).
- **Two regression tests**: a Reach+Impact-only board sorts with `confidence=1` (`rice == 6.0`); a board missing Impact still returns `code == 400` with `"impact"` in `missing`.
- **Version bump** 2.9.0 → 2.10.0.

## Why
`shikenso-development` dropped Business Priorisation / Story Points Left / Confidence down to **Reach + Impact** only (Effort already comes from native story points via `set_userstory_points_tool`). The old 3-attr gate made the RICE sort unusable there.

## Validation
- `pytest --disable-socket --allow-unix-socket tests/unit_tests/` → **284 passed, 1 skipped**.
- The with-Confidence path is unchanged — the pre-existing tests run against a 3-attr board and stay green.

## Notes / follow-ups
- The 400 payload is **additively** extended (`missing` key added; `required` no longer lists `confidence`). No in-repo consumer asserts the old shape; flagging for any external parser of this error.
- **Codex review (normal): 1 P2 finding — won't-fix (documented).** A board sorted while it has *no* Confidence attribute, then *given* one, keeps scoring `confidence=1` until the 5-min `_discover_sort_attr_ids` cache expires. Accepted as a bounded transient: the same staleness already applies to renaming Reach/Impact, and boards that intentionally omit Confidence (the common case here) score 1 correctly and permanently. Codex's literal fix (cache bypass on confidence-absent) would add an API round-trip to **every** confidence-less sort, regressing the intended common case. Documented in the docstring + a maintainer comment at the gate instead.

Codex-Review: normal, 1 finding (P2 cache-staleness) — won't-fix, documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)